### PR TITLE
LIS new capacity policy

### DIFF
--- a/src/SPECK3D.cpp
+++ b/src/SPECK3D.cpp
@@ -83,16 +83,10 @@ void speck::SPECK3D::m_clean_LIS()
             m_LIS_garbage_cnt[i] >= m_LIS[i].size() / 2  )
         {
             auto& list = m_LIS[i];
-            /*tmp.clear();
-            tmp.reserve( m_vec_init_capacity );
-            for( const auto& s : m_LIS[i] )
-                if( s.type != SetType::Garbage )
-                    tmp.push_back( s ); */
             tmp.clear();
-            tmp.reserve(  list.size() );    // will have at least half spaces empty
+            tmp.reserve(  list.size() );    // make sure list won't see a capacity decrease
             std::copy_if( list.cbegin(), list.cend(), std::back_inserter(tmp),
                           []( const SPECKSet3D& s ){ return s.type != SetType::Garbage; } );
-
             std::swap( list, tmp );
             m_LIS_garbage_cnt[i] = 0;
         }


### PR DESCRIPTION
Adjust the size policy of LIS lists (implemented using std::vector<>): the new policy is that it will have at least half empty reserved *capacity* after a clean operation.

It aims to avoid a scenario where a list grows to size X, cleaned to size X/2, and then re-grows to X, while requesting a memory allocation. 

It will result in slightly less efficient memory utilization. But in one test, both clang and gcc report a ~4% performance improvement. 