### PR TITLE
Introduce lip

### DIFF
--- a/src/SPECK3D.h
+++ b/src/SPECK3D.h
@@ -68,7 +68,7 @@ private:
     bool m_ready_to_decode() const;
     // How many partition operation could we perform in each direction?
     void m_num_of_partitions( std::array<size_t, 3>& ) const; 
-    void m_clean_LIS();   // Clean garbage sets from m_LIS if too much garbage exists.
+    void m_clean_LIS();             // Clean garbage sets from m_LIS if too much garbage exists.
     void m_initialize_sets_lists();
     int  m_sorting_pass_encode( );
     int  m_sorting_pass_decode( );
@@ -80,7 +80,7 @@ private:
     int  m_process_S_decode( size_t idx1, size_t idx2 );
     int  m_code_S          ( size_t idx1, size_t idx2 );
     int  m_process_P_encode( size_t idx );  // Same functionality as process_S, but specifically
-    int  m_process_P_decode( size_t idx );  // designed for the list of insignificant pixels.
+    int  m_process_P_decode( size_t idx );  // designed for sets that are essentially pixels.
 
     void m_partition_S_XYZ(const SPECKSet3D& set, std::array<SPECKSet3D, 8>& subsets ) const;
     void m_partition_S_XY( const SPECKSet3D& set, std::array<SPECKSet3D, 4>& subsets ) const;
@@ -91,9 +91,9 @@ private:
     // Private data members
     //
 #ifdef SPECK_USE_DOUBLE
-    double      m_threshold = 0.0;      // Threshold that's used for quantization
+    double      m_threshold   = 0.0;    // Threshold that's used for quantization
 #else
-    float       m_threshold = 0.0f;
+    float       m_threshold   = 0.0f;
 #endif
     size_t      m_budget      = 0;      // What's the budget for num of bits?
     size_t      m_bit_idx     = 0;      // Used for decode. Which bit we're at?
@@ -106,7 +106,7 @@ private:
     std::vector< std::vector<SPECKSet3D> >  m_LIS;
     std::vector<size_t>                     m_LIS_garbage_cnt;
 
-    std::vector<bool  >  m_significance_map;// only used when encoding.
+    std::vector<bool  >  m_significance_map;    // only used when encoding.
     std::vector<bool  >  m_sign_array;
 
     std::vector<size_t>  m_LSP;         // Records locations of significant pixels

--- a/test_scripts/speck3d_unit_test.cpp
+++ b/test_scripts/speck3d_unit_test.cpp
@@ -121,11 +121,17 @@ TEST( speck3d, small )
     EXPECT_GT( psnr, 52.559024 );
     EXPECT_LT( lmax,  1.432911 );
 
+    tester.execute( 16.0f );
+    psnr = tester.get_psnr();
+    lmax = tester.get_lmax();
+    EXPECT_GT( psnr, 41.48256 );
+    EXPECT_LT( lmax, 5.468170 );
+
     tester.execute( 32.0f );
     psnr = tester.get_psnr();
     lmax = tester.get_lmax();
-    EXPECT_GT( psnr, 34.71057 );
-    EXPECT_LT( lmax, 12.45794 );
+    EXPECT_GT( psnr, 34.713616 );
+    EXPECT_LT( lmax, 12.496039 );
 
     tester.execute( 64.0f );
     psnr = tester.get_psnr();

--- a/utilities/compressor_3d.cpp
+++ b/utilities/compressor_3d.cpp
@@ -17,7 +17,7 @@ int main( int argc, char* argv[] )
 {
     if( argc != 8 )
     {
-        std::cerr << "Usage: ./a.out input_filename dim_x dim_y dim_z  "
+        std::cerr << "Usage: ./a.out input_filename dim_x dim_y dim_z "
                   << "ordering(XYZ or ZYX) output_filename bits_per_pixel " << std::endl;
         return 1;
     }


### PR DESCRIPTION
Description: 
This PR implements a LIP, List of Insignificant Pixels, which uses pixel indices instead of a `SPECKSet3D`s to hold insignificant pixels. The benefit would be reduced memory consumption and faster execution.

On a test run: 

`./compressor_3d /home/shaomeng/Git/SPECK2020/test_data/wmag512.float 512 512 512 XYZ tmp 4`

The high water mark memory consumption reduces from 8GB to 4GB.

The compression time reduces from 24s to 20s

The decompression time reduces from 15s to 11s.