### PR TITLE
remove sig map

### DIFF
--- a/src/SPECK3D.h
+++ b/src/SPECK3D.h
@@ -112,10 +112,7 @@ private:
     // List of significant pixels (recorded as locations).
     vector_size_t       m_LSP_new; // Ones newly identified as significant
     vector_size_t       m_LSP_old; // Ones previously identified as significant
-
     vector_bool         m_sign_array;
-    vector_bool         m_sig_map;
-    bool                m_sig_map_enabled;
 
 #ifdef USE_PMR
     std::pmr::vector<std::pmr::vector<SPECKSet3D>>  m_LIS;


### PR DESCRIPTION
This PR removes the use of a significance map. Instead, a coefficient will always need to directly compare with `m_threshold` to decide its significance. This change proves to provide a consistent, though modest (less than 1s), performance improvement on servers (Casper, thunder). It hurt performance on laptops (macbook). Given the intended use scenario is on servers, and the greatly simplified code, I decide to incorporate this change. 