### PR TITLE
Accuracy gain

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![clang-tidy](https://github.com/NCAR/SPERR/actions/workflows/clang-tidy.yml/badge.svg)](https://github.com/NCAR/SPERR/actions/workflows/clang-tidy.yml)
 [![unit-test](https://github.com/NCAR/SPERR/actions/workflows/unit-test.yml/badge.svg)](https://github.com/NCAR/SPERR/actions/workflows/unit-test.yml)
 [![CodeQL](https://github.com/NCAR/SPERR/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/NCAR/SPERR/actions/workflows/codeql-analysis.yml)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/5fb9befd9687440195ca739ec60abc39)](https://www.codacy.com/gh/shaomeng/SPERR-personal/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=shaomeng/SPERR-personal&amp;utm_campaign=Badge_Grade)
 
 ## Overview
 

--- a/include/sperr_helper.h
+++ b/include/sperr_helper.h
@@ -126,7 +126,7 @@ auto read_n_bytes(std::string filename, size_t n_bytes) -> std::vector<uint8_t>;
 // ret[3] : min of arr1
 // ret[4] : max of arr1
 template <typename T>
-auto calc_stats(const T* arr1, const T* arr2, size_t arr_len, size_t omp_nthreads)
+auto calc_stats(const T* arr1, const T* arr2, size_t arr_len, size_t omp_nthreads = 0)
     -> std::array<T, 5>;
 
 template <typename T>
@@ -178,8 +178,9 @@ auto parse_header(const void*) -> HeaderInfo;
 
 // Calculate the variance of a given array.
 // In case of arrays of size zero, it will return std::numeric_limits<T>::infinity().
+// In case of `omp_nthreads == 0`, it will use all available OpenMP threads.
 template <typename T>
-auto calc_variance(const T*, size_t) -> T;
+auto calc_variance(const T*, size_t len, size_t omp_nthreads = 0) -> T;
 
 // Decide compression mode based on a collection of parameters.
 auto compression_mode(size_t bit_budget, double psnr, double pwe) -> CompMode;

--- a/utilities/compressor_2d.cpp
+++ b/utilities/compressor_2d.cpp
@@ -160,7 +160,7 @@ int main(int argc, char* argv[])
 
   // Calculate and print statistics
   if (show_stats) {
-    std::cout << "Average bpp = " << stream.size() * 8.0 / total_vals;
+    const auto bpp = stream.size() * 8.0 / total_vals;
 
     // Use a decompressor to decompress and collect error statistics
     SPERR2D_Decompressor decompressor;
@@ -176,17 +176,27 @@ int main(int argc, char* argv[])
       const auto& recover = decompressor.view_data();
       assert(recover.size() * sizeof(double) == orig.size());
       auto stats = sperr::calc_stats(reinterpret_cast<const double*>(orig.data()), recover.data(),
-                                     recover.size(), 0);
-      std::cout << ", PSNR = " << stats[2] << "dB,  L-Infty = " << stats[1];
-      std::printf(", Data range = %.2e (%.2e, %.2e).\n", (stats[4] - stats[3]), stats[3], stats[4]);
+                                     recover.size());
+      auto var = sperr::calc_variance(reinterpret_cast<const double*>(orig.data()), total_vals);
+      auto sigma = std::sqrt(var);
+      auto gain = std::log2(sigma / stats[0]) - bpp;
+      std::cout << "Average BPP = " << bpp << ", PSNR = " << stats[2]
+                << "dB, L-Infty = " << stats[1] << ", Accuracy Gain = " << gain << std::endl;
+      std::printf("Input data range = %.2e (%.2e, %.2e).\n", (stats[4] - stats[3]), stats[3],
+                  stats[4]);
     }
     else {
       const auto recover = decompressor.get_data<float>();
       assert(recover.size() * sizeof(float) == orig.size());
       auto stats = sperr::calc_stats(reinterpret_cast<const float*>(orig.data()), recover.data(),
-                                     recover.size(), 0);
-      std::cout << ", PSNR = " << stats[2] << "dB,  L-Infty = " << stats[1];
-      std::printf(", Data range = %.2e (%.2e, %.2e).\n", (stats[4] - stats[3]), stats[3], stats[4]);
+                                     recover.size());
+      auto var = sperr::calc_variance(reinterpret_cast<const float*>(orig.data()), total_vals);
+      auto sigma = std::sqrt(var);
+      auto gain = std::log2(sigma / stats[0]) - float(bpp);
+      std::cout << "Average BPP = " << bpp << ", PSNR = " << stats[2]
+                << "dB, L-Infty = " << stats[1] << ", Accuracy Gain = " << gain << std::endl;
+      std::printf("Input data range = %.2e (%.2e, %.2e).\n", (stats[4] - stats[3]), stats[3],
+                  stats[4]);
     }
 
     if (mode == sperr::CompMode::FixedPWE) {

--- a/utilities/compressor_3d.cpp
+++ b/utilities/compressor_3d.cpp
@@ -204,7 +204,7 @@ int main(int argc, char* argv[])
       auto var = sperr::calc_variance(reinterpret_cast<const double*>(orig.data()), total_vals,
                                       omp_num_threads);
       auto sigma = std::sqrt(var);
-      auto gain = std::log2(sigma / stats[1]) - bpp;
+      auto gain = std::log2(sigma / stats[0]) - bpp;
       std::cout << "Average BPP = " << bpp << ", PSNR = " << stats[2]
                 << "dB, L-Infty = " << stats[1] << ", Accuracy Gain = " << gain << std::endl;
       std::printf("Input data range = %.2e (%.2e, %.2e).\n", (stats[4] - stats[3]), stats[3],
@@ -215,11 +215,10 @@ int main(int argc, char* argv[])
       assert(recover.size() * sizeof(float) == orig.size());
       auto stats = sperr::calc_stats(reinterpret_cast<const float*>(orig.data()), recover.data(),
                                      recover.size(), omp_num_threads);
-
       auto var = sperr::calc_variance(reinterpret_cast<const float*>(orig.data()), total_vals,
                                       omp_num_threads);
       auto sigma = std::sqrt(var);
-      auto gain = std::log2(sigma / stats[1]) - float(bpp);
+      auto gain = std::log2(sigma / stats[0]) - float(bpp);
       std::cout << "Average BPP = " << bpp << ", PSNR = " << stats[2]
                 << "dB, L-Infty = " << stats[1] << ", Accuracy Gain = " << gain << std::endl;
       std::printf("Input data range = %.2e (%.2e, %.2e).\n", (stats[4] - stats[3]), stats[3],


### PR DESCRIPTION
This PR add Accuracy Gain output in its command line utilities, and also added a code quality badge. 

Note: gain = log2(s / E) - R, where s is the standard deviation of the original data, E is the root-mean-square error, and R is the rate in bits/value (aka. BPP).