### PR TITLE
implement a new logic to decide between dyadic and wavelet packets 3D…

### DIFF
--- a/include/CDF97.h
+++ b/include/CDF97.h
@@ -37,15 +37,11 @@ class CDF97 {
 
   // Action items
   void dwt1d();
+  void dwt2d();
+  void dwt3d();
+  void idwt2d();
   void idwt1d();
-  void dwt2d();   // 1) calculates the number of levels of dwt,
-                  // 2) perform the actual dwt.
-  void idwt2d();  // 1) calculates the number of levels of dwt,
-                  // 2) perform the actual idwt
-  void dwt3d_wavelet_packet();
-  void idwt3d_wavelet_packet();
-  void dwt3d_dyadic();
-  void idwt3d_dyadic();
+  void idwt3d();
 
  private:
   using itd_type = vecd_type::iterator;
@@ -91,6 +87,13 @@ class CDF97 {
   // Note 2: two versions for even and odd length input.
   void m_scatter_even(citd_type begin, citd_type end, itd_type dest) const;
   void m_scatter_odd(citd_type begin, citd_type end, itd_type dest) const;
+
+  // Two flavors of 3D transforms.
+  // They should be invoked by the `dwt3d()` and `idwt3d()` public methods though.
+  void m_dwt3d_wavelet_packet();
+  void m_idwt3d_wavelet_packet();
+  void m_dwt3d_dyadic();
+  void m_idwt3d_dyadic();
 
   //
   // Methods from QccPack, so keep their original names, interface, and the use of raw pointers.

--- a/include/CDF97.h
+++ b/include/CDF97.h
@@ -89,7 +89,7 @@ class CDF97 {
   void m_scatter_odd(citd_type begin, citd_type end, itd_type dest) const;
 
   // Two flavors of 3D transforms.
-  // They should be invoked by the `dwt3d()` and `idwt3d()` public methods though.
+  // They should be invoked by the `dwt3d()` and `idwt3d()` public methods, not users, though.
   void m_dwt3d_wavelet_packet();
   void m_idwt3d_wavelet_packet();
   void m_dwt3d_dyadic();

--- a/src/CDF97.cpp
+++ b/src/CDF97.cpp
@@ -96,9 +96,11 @@ void sperr::CDF97::dwt3d()
   // 2) ELSE IF XY and Z have different levels, THEN use wavelet packets;
   // 3) ELSE use dyadic.
   //
-  const auto num_xforms =
-      std::array<size_t, 3>{sperr::num_of_xforms(m_dims[0]), sperr::num_of_xforms(m_dims[1]),
-                            sperr::num_of_xforms(m_dims[2])};
+  // clang-format off
+  const auto num_xforms = std::array<size_t, 3>{sperr::num_of_xforms(m_dims[0]),
+                                                sperr::num_of_xforms(m_dims[1]),
+                                                sperr::num_of_xforms(m_dims[2])};
+  // clang-format on
 
   if (num_xforms[0] >= 5 && num_xforms[1] >= 5 && num_xforms[2] >= 5) {
     m_dwt3d_dyadic();
@@ -113,9 +115,11 @@ void sperr::CDF97::dwt3d()
 
 void sperr::CDF97::idwt3d()
 {
-  const auto num_xforms =
-      std::array<size_t, 3>{sperr::num_of_xforms(m_dims[0]), sperr::num_of_xforms(m_dims[1]),
-                            sperr::num_of_xforms(m_dims[2])};
+  // clang-format off
+  const auto num_xforms = std::array<size_t, 3>{sperr::num_of_xforms(m_dims[0]),
+                                                sperr::num_of_xforms(m_dims[1]),
+                                                sperr::num_of_xforms(m_dims[2])};
+  // clang-format on
 
   if (num_xforms[0] >= 5 && num_xforms[1] >= 5 && num_xforms[2] >= 5) {
     m_idwt3d_dyadic();
@@ -246,10 +250,12 @@ void sperr::CDF97::m_idwt3d_wavelet_packet()
 
 void sperr::CDF97::m_dwt3d_dyadic()
 {
-  const auto xforms =
-      std::array<size_t, 3>{sperr::num_of_xforms(m_dims[0]), sperr::num_of_xforms(m_dims[1]),
-                            sperr::num_of_xforms(m_dims[2])};
+  // clang-format off
+  const auto xforms = std::array<size_t, 3>{sperr::num_of_xforms(m_dims[0]),
+                                            sperr::num_of_xforms(m_dims[1]),
+                                            sperr::num_of_xforms(m_dims[2])};
   const auto num_xforms = *std::min_element(xforms.cbegin(), xforms.cend());
+  // clang-format on
 
   for (size_t lev = 0; lev < num_xforms; lev++) {
     auto app_x = sperr::calc_approx_detail_len(m_dims[0], lev);
@@ -261,10 +267,12 @@ void sperr::CDF97::m_dwt3d_dyadic()
 
 void sperr::CDF97::m_idwt3d_dyadic()
 {
-  const auto xforms =
-      std::array<size_t, 3>{sperr::num_of_xforms(m_dims[0]), sperr::num_of_xforms(m_dims[1]),
-                            sperr::num_of_xforms(m_dims[2])};
+  // clang-format off
+  const auto xforms = std::array<size_t, 3>{sperr::num_of_xforms(m_dims[0]),
+                                            sperr::num_of_xforms(m_dims[1]),
+                                            sperr::num_of_xforms(m_dims[2])};
   const auto num_xforms = *std::min_element(xforms.cbegin(), xforms.cend());
+  // clang-format on
 
   for (size_t lev = num_xforms; lev > 0; lev--) {
     auto app_x = sperr::calc_approx_detail_len(m_dims[0], lev - 1);

--- a/src/SPERR3D_Compressor.cpp
+++ b/src/SPERR3D_Compressor.cpp
@@ -90,14 +90,7 @@ auto sperr::SPERR3D_Compressor::compress() -> RTNType
   rtn = m_cdf.take_data(std::move(m_val_buf), m_dims);
   if (rtn != RTNType::Good)
     return rtn;
-  // Figure out which dwt3d strategy to use.
-  // Note: this strategy needs to be consistent with SPERR3D_Decompressor.
-  const auto xforms_xy = sperr::num_of_xforms(std::min(m_dims[0], m_dims[1]));
-  const auto xforms_z = sperr::num_of_xforms(m_dims[2]);
-  if (xforms_xy == xforms_z)
-    m_cdf.dwt3d_dyadic();
-  else
-    m_cdf.dwt3d_wavelet_packet();
+  m_cdf.dwt3d();
 
   // Step 3: SPECK encoding
   rtn = m_encoder.take_data(m_cdf.release_data(), m_dims);
@@ -132,10 +125,7 @@ auto sperr::SPERR3D_Compressor::compress() -> RTNType
     auto qz_coeff = m_encoder.release_quantized_coeff();
     assert(!qz_coeff.empty());
     m_cdf.take_data(std::move(qz_coeff), m_dims);
-    if (xforms_xy == xforms_z)
-      m_cdf.idwt3d_dyadic();
-    else
-      m_cdf.idwt3d_wavelet_packet();
+    m_cdf.idwt3d();
     m_val_buf = m_cdf.release_data();
     m_conditioner.inverse_condition(m_val_buf, m_condi_stream);
 

--- a/src/SPERR3D_Decompressor.cpp
+++ b/src/SPERR3D_Decompressor.cpp
@@ -116,15 +116,7 @@ auto sperr::SPERR3D_Decompressor::decompress() -> RTNType
   //  processing the next chunk. For the same reason, `m_cdf` keeps its memory.)
   const auto& decoder_out = m_decoder.view_data();
   m_cdf.copy_data(decoder_out.data(), decoder_out.size(), m_dims);
-
-  // Figure out which dwt3d strategy to use.
-  // Note: this strategy needs to be consistent with SPERR3D_Compressor.
-  const auto xforms_xy = sperr::num_of_xforms(std::min(m_dims[0], m_dims[1]));
-  const auto xforms_z = sperr::num_of_xforms(m_dims[2]);
-  if (xforms_xy == xforms_z)
-    m_cdf.idwt3d_dyadic();
-  else
-    m_cdf.idwt3d_wavelet_packet();
+  m_cdf.idwt3d();
 
   // Step 3: Inverse Conditioning
   const auto& cdf_out = m_cdf.view_data();

--- a/test_scripts/dwt_unit_test.cpp
+++ b/test_scripts/dwt_unit_test.cpp
@@ -236,7 +236,7 @@ TEST(dwt3d, small_even_cube)
 
   // Use a sperr::CDF97 to perform DWT and IDWT.
   sperr::CDF97 cdf;
-  cdf.copy_data(in_copy.data(), dim_x * dim_y * dim_z, {dim_x, dim_y, dim_z});
+  cdf.take_data(std::move(in_copy), {dim_x, dim_y, dim_z});
   cdf.dwt3d();
   cdf.idwt3d();
 
@@ -270,7 +270,7 @@ TEST(dwt3d, big_odd_cube)
 
   // Use a sperr::CDF97 to perform DWT and IDWT.
   sperr::CDF97 cdf;
-  cdf.copy_data(in_copy.data(), dim_x * dim_y * dim_z, {dim_x, dim_y, dim_z});
+  cdf.take_data(std::move(in_copy), {dim_x, dim_y, dim_z});
   cdf.dwt3d();
   cdf.idwt3d();
 
@@ -304,7 +304,7 @@ TEST(dwt3d, big_even_cube)
 
   // Use a sperr::CDF97 to perform DWT and IDWT.
   sperr::CDF97 cdf;
-  cdf.copy_data(in_copy.data(), dim_x * dim_y * dim_z, {dim_x, dim_y, dim_z});
+  cdf.take_data(std::move(in_copy), {dim_x, dim_y, dim_z});
   cdf.dwt3d();
   cdf.idwt3d();
 

--- a/test_scripts/dwt_unit_test.cpp
+++ b/test_scripts/dwt_unit_test.cpp
@@ -234,30 +234,17 @@ TEST(dwt3d, small_even_cube)
   auto condi = sperr::Conditioner();
   auto [rtn, meta] = condi.condition(in_copy);
 
-  // Use a sperr::CDF97 to perform DWT and IDWT, wavelet-packet.
+  // Use a sperr::CDF97 to perform DWT and IDWT.
   sperr::CDF97 cdf;
   cdf.copy_data(in_copy.data(), dim_x * dim_y * dim_z, {dim_x, dim_y, dim_z});
-  cdf.dwt3d_wavelet_packet();
-  cdf.idwt3d_wavelet_packet();
+  cdf.dwt3d();
+  cdf.idwt3d();
 
   // Claim that with single precision, the result is identical to the input
   auto result = cdf.release_data();
   EXPECT_EQ(result.size(), total_vals);
 
   // Apply the conditioner
-  rtn = condi.inverse_condition(result, meta);
-  for (size_t i = 0; i < total_vals; i++) {
-    EXPECT_EQ(in_buf[i], float(result[i]));
-  }
-
-  // Also test dyadic strategy:
-  cdf.take_data(std::move(in_copy), {dim_x, dim_y, dim_z});
-  cdf.dwt3d_dyadic();
-  cdf.idwt3d_dyadic();
-
-  result = cdf.release_data();
-  EXPECT_EQ(result.size(), total_vals);
-
   rtn = condi.inverse_condition(result, meta);
   for (size_t i = 0; i < total_vals; i++) {
     EXPECT_EQ(in_buf[i], float(result[i]));
@@ -281,30 +268,17 @@ TEST(dwt3d, big_odd_cube)
   auto condi = sperr::Conditioner();
   auto [rtn, meta] = condi.condition(in_copy);
 
-  // Use a sperr::CDF97 to perform DWT and IDWT, wavelet-packet
+  // Use a sperr::CDF97 to perform DWT and IDWT.
   sperr::CDF97 cdf;
   cdf.copy_data(in_copy.data(), dim_x * dim_y * dim_z, {dim_x, dim_y, dim_z});
-  cdf.dwt3d_wavelet_packet();
-  cdf.idwt3d_wavelet_packet();
+  cdf.dwt3d();
+  cdf.idwt3d();
 
   // Claim that with single precision, the result is identical to the input
   auto result = cdf.release_data();
   EXPECT_EQ(result.size(), total_vals);
 
   // Apply the conditioner
-  rtn = condi.inverse_condition(result, meta);
-  for (size_t i = 0; i < total_vals; i++) {
-    EXPECT_EQ(in_buf[i], float(result[i]));
-  }
-
-  // Also test dyadic strategy
-  cdf.take_data(std::move(in_copy), {dim_x, dim_y, dim_z});
-  cdf.dwt3d_dyadic();
-  cdf.idwt3d_dyadic();
-
-  result = cdf.release_data();
-  EXPECT_EQ(result.size(), total_vals);
-
   rtn = condi.inverse_condition(result, meta);
   for (size_t i = 0; i < total_vals; i++) {
     EXPECT_EQ(in_buf[i], float(result[i]));
@@ -328,30 +302,17 @@ TEST(dwt3d, big_even_cube)
   auto condi = sperr::Conditioner();
   auto [rtn, meta] = condi.condition(in_copy);
 
-  // Use a sperr::CDF97 to perform DWT and IDWT: wavelet-packet strategy
+  // Use a sperr::CDF97 to perform DWT and IDWT.
   sperr::CDF97 cdf;
   cdf.copy_data(in_copy.data(), dim_x * dim_y * dim_z, {dim_x, dim_y, dim_z});
-  cdf.dwt3d_wavelet_packet();
-  cdf.idwt3d_wavelet_packet();
+  cdf.dwt3d();
+  cdf.idwt3d();
 
   // Claim that with single precision, the result is identical to the input
   auto result = cdf.release_data();
   EXPECT_EQ(result.size(), total_vals);
 
   // Apply the conditioner
-  rtn = condi.inverse_condition(result, meta);
-  for (size_t i = 0; i < total_vals; i++) {
-    EXPECT_EQ(in_buf[i], float(result[i]));
-  }
-
-  // Also test dyadic strategy
-  cdf.take_data(std::move(in_copy), {dim_x, dim_y, dim_z});
-  cdf.dwt3d_dyadic();
-  cdf.idwt3d_dyadic();
-
-  result = cdf.release_data();
-  EXPECT_EQ(result.size(), total_vals);
-
   rtn = condi.inverse_condition(result, meta);
   for (size_t i = 0; i < total_vals; i++) {
     EXPECT_EQ(in_buf[i], float(result[i]));


### PR DESCRIPTION
Observation: in 3D cases, _dyadic_ transform ordering seems to reduce error quite a bit compared to _wavelet packet_. 

This PR changes the logic to decide which ordering to use. Specifically, When all axes can support 5 or more levels of transform, use dyadic no matter if they are the same or not. 

The following example demonstrates this difference. Using Miranda Viscosity at 384x384x256 resolution and a chunk size of 192x192x256, the old cold would use wavelet packet, and have 5 levels on XY plane and 6 levels on Z columns. This PR changes the behavior so that it'll do 5 levels of transforms using dyadic strategy. The PSNR has increased across the board from low to high BPP.

| BPP | Old PSNR | New PSNR |
|----- |------------|-------------|
| 1.0  | 107.79  | 116.78  |
| 2.0  | 129.85  | 142.41  |
| 4.0  | 163.38  | 182.47  |
| 8.0  | 216.73  | 240.42  |
| 16.0 | 277.46 | 291.42  |
| 24.0 | 324.59 | 331.65  |