### PR TITLE
Wrap zfp bitstream in C++ class

### DIFF
--- a/include/ZFP_bitstream.h
+++ b/include/ZFP_bitstream.h
@@ -1,0 +1,62 @@
+#ifndef ZFP_BITSTREAM_H
+#define ZFP_BITSTREAM_H
+
+#include "bitstream.inl"
+
+#include <cassert>
+#include <memory>
+#include <vector>
+
+namespace sperr {
+
+class ZFP_bitstream {
+ public:
+  // Constructor
+  // How many bits does it hold initially?
+  ZFP_bitstream(size_t nbits = 1024);
+
+  // Functions for both read and write
+  void rewind();
+  auto capacity() const -> size_t;
+
+  // Functions for read
+  auto rtell() const -> size_t;
+  void rseek(size_t offset);
+  auto read_bit() -> bool { return zfp::stream_read_bit(m_handle.get()); }
+  auto test_range(size_t start_pos, size_t range_len) -> bool
+  {
+    return zfp::stream_test_range(m_handle.get(), start_pos, range_len);
+  }
+
+  // Functions for write
+  auto wtell() const -> size_t;
+  void wseek(size_t offset);
+  auto flush() -> size_t;  // See ZFP API for return value meaning
+  auto write_n_bits(uint64_t value, size_t n) -> uint64_t
+  {
+    assert(n <= 64);
+    if (zfp::stream_wtell(m_handle.get()) + n > m_capacity)
+      m_wgrow_buf();
+    return zfp::stream_write_bits(m_handle.get(), value, n);
+  }
+  auto write_bit(bool bit) -> bool
+  {
+    if (zfp::stream_wtell(m_handle.get()) == m_capacity)
+      m_wgrow_buf();
+    return zfp::stream_write_bit(m_handle.get(), bit);
+  }
+
+ private:
+  std::unique_ptr<zfp::bitstream, decltype(&zfp::stream_close)> m_handle = {nullptr,
+                                                                            &zfp::stream_close};
+  std::vector<uint64_t> m_buf;
+
+  size_t m_capacity = 0;
+
+  // Grows the buffer in write mode
+  void m_wgrow_buf();
+};
+
+};  // namespace sperr
+
+#endif

--- a/include/bitstream.inl
+++ b/include/bitstream.inl
@@ -1,0 +1,519 @@
+/*
+High-speed in-memory bit stream I/O that supports reading and writing between
+0 and 64 bits at a time.  The implementation, which relies heavily on bit
+shifts, has been carefully written to ensure that all shifts are between
+zero and one less the width of the type being shifted to avoid undefined
+behavior.  This occasionally causes somewhat convoluted code.
+
+The following assumptions and restrictions apply:
+
+1. The user must allocate a memory buffer large enough to hold the bit stream,
+   whether for reading, writing, or both.  This buffer is associated with the
+   bit stream via stream_open(buffer, bytes), which allocates and returns a
+   pointer to an opaque bit stream struct.  Call stream_close(stream) to
+   deallocate this struct.
+
+2. The stream is either in a read or write state (or, initially, in both
+   states).  When done writing, call stream_flush(stream) before entering
+   read mode to ensure any buffered bits are output.  To enter read mode,
+   call stream_rewind(stream) or stream_rseek(stream, offset) to position
+   the stream at the beginning or at a particular bit offset.  Conversely,
+   stream_rewind(stream) or stream_wseek(stream, offset) positions the
+   stream for writing.  In read mode, the following functions may be called:
+
+     size_t stream_size(stream);
+     bitstream_offset stream_rtell(stream);
+     void stream_rewind(stream);
+     void stream_rseek(stream, offset);
+     void stream_skip(stream, n);
+     bitstream_count stream_align(stream);
+     uint stream_read_bit(stream);
+     uint64 stream_read_bits(stream, n);
+
+   Each of the above read calls has a corresponding write call:
+
+     size_t stream_size(stream);
+     bitstream_offset stream_wtell(stream);
+     void stream_rewind(stream);
+     void stream_wseek(stream, offset);
+     void stream_pad(stream, n);
+     bitstream_count stream_flush(stream);
+     uint stream_write_bit(stream, bit);
+     uint64 stream_write_bits(stream, value, n);
+
+3. The stream buffer is an unsigned integer of a user-specified type given
+   by the BIT_STREAM_WORD_TYPE macro.  Bits are read and written in units of
+   this integer word type.  Supported types are 8, 16, 32, or 64 bits wide.
+   The bit width of the buffer is denoted by 'wsize' and can be accessed
+   either via the global constant stream_word_bits or stream_alignment().
+   A small wsize allows for fine granularity reads and writes, and may be
+   preferable when working with many small blocks of data that require
+   non-sequential access.  The default maximum size of 64 bits ensures maximum
+   speed.  Note that even when wsize < 64, it is still possible to read and
+   write up to 64 bits at a time using stream_read_bits() and
+   stream_write_bits().
+
+4. If BIT_STREAM_STRIDED is defined, words read from or written to the stream
+   may be accessed noncontiguously by setting a power-of-two block size (which
+   by default is one word) and a block stride (defaults to zero blocks).  The
+   word pointer is always incremented by one word each time a word is accessed.
+   Once advanced past a block boundary, the word pointer is also advanced by
+   the stride to the next block.  This feature may be used to store blocks of
+   data interleaved, e.g., for progressive coding or for noncontiguous parallel
+   access to the bit stream  Note that the block size is measured in words,
+   while the stride is measured in multiples of the block size.  Strided access
+   can have a significant performance penalty.
+
+5. Multiple bits are read and written in order of least to most significant
+   bit.  Thus, the statement
+
+       value = stream_write_bits(stream, value, n);
+
+   is essentially equivalent to (but faster than)
+
+       for (i = 0; i < n; i++, value >>= 1)
+         stream_write_bit(stream, value & 1);
+
+   when 0 <= n <= 64.  The same holds for read calls, and thus
+
+       value = stream_read_bits(stream, n);
+
+   is essentially equivalent to
+
+       for (i = 0, value = 0; i < n; i++)
+         value += (uint64)stream_read_bit(stream) << i;
+
+   Note that it is possible to write fewer bits than the argument 'value'
+   holds (possibly even no bits), in which case any unwritten bits are
+   shifted right to the least significant position and returned.  That is,
+   value = stream_write_bits(stream, value, n); is equivalent to
+
+       for (i = 0; i < n; i++)
+         value = stream_write_bits(stream, value, 1);
+
+6. Although the stream_wseek(stream, offset) call allows positioning the
+   stream for writing at any bit offset without any data loss (i.e. all
+   previously written bits preceding the offset remain valid), for efficiency
+   the stream_flush(stream) operation will zero all bits up to the next
+   multiple of wsize bits, thus overwriting bits that were previously stored
+   at that location.  Consequently, random write access is effectively
+   supported only at wsize granularity.  For sequential access, the largest
+   possible wsize is preferred due to higher speed.
+
+7. It is up to the user to adhere to these rules.  For performance reasons,
+   no error checking is done, and in particular buffer overruns are not
+   caught.
+*/
+
+#include <climits>  // sam
+#include <cstddef>  // sam
+#include <cstdint>  // sam
+#include <cstdlib>  // sam
+
+#ifndef inline_
+  #define inline_
+#endif
+
+// #include "zfp/bitstream.h"  // Sam removed it
+
+namespace zfp {  // sam
+
+typedef unsigned int uint;          // sam
+typedef uint64_t uint64;            // sam
+typedef struct bitstream bitstream; // sam: forward declaration of opaque type */
+typedef uint64 bitstream_offset;    // sam: bit offset into stream where bits are read/written
+typedef bitstream_offset bitstream_size; // sam: type for counting number of bits in a stream
+typedef size_t bitstream_count; // sam: type for counting a small number of bits in a stream
+
+/* satisfy compiler when args unused */
+#define unused_(x) ((void)(x))
+
+/* bit stream word/buffer type; granularity of stream I/O operations */
+#ifdef BIT_STREAM_WORD_TYPE
+  /* may be 8-, 16-, 32-, or 64-bit unsigned integer type */
+  typedef BIT_STREAM_WORD_TYPE bitstream_word;
+#else
+  /* use maximum word size by default for highest speed */
+  typedef uint64 bitstream_word;
+#endif
+
+/* number of bits in a buffered word */
+#define wsize ((bitstream_count)(sizeof(bitstream_word) * CHAR_BIT))
+
+/* bit stream structure (opaque to caller) */
+struct bitstream {
+  bitstream_count bits;  /* number of buffered bits (0 <= bits < wsize) */
+  bitstream_word buffer; /* incoming/outgoing bits (buffer < 2^bits) */
+  bitstream_word* ptr;   /* pointer to next word to be read/written */
+  bitstream_word* begin; /* beginning of stream */
+  bitstream_word* end;   /* end of stream (not enforced) */
+#ifdef BIT_STREAM_STRIDED
+  size_t mask;           /* one less the block size in number of words */
+  ptrdiff_t delta;       /* number of words between consecutive blocks */
+#endif
+};
+
+/* private functions ------------------------------------------------------- */
+
+/* read a single word from memory */
+static bitstream_word
+stream_read_word(bitstream* s)
+{
+  bitstream_word w = *s->ptr++;
+#ifdef BIT_STREAM_STRIDED
+  if (!((s->ptr - s->begin) & s->mask))
+    s->ptr += s->delta;
+#endif
+  return w;
+}
+
+/* write a single word to memory */
+static void
+stream_write_word(bitstream* s, bitstream_word value)
+{
+  *s->ptr++ = value;
+#ifdef BIT_STREAM_STRIDED
+  if (!((s->ptr - s->begin) & s->mask))
+    s->ptr += s->delta;
+#endif
+}
+
+/* public functions -------------------------------------------------------- */
+
+/* word size in bits (equals bitstream_word_bits) */
+inline_ bitstream_count
+stream_alignment()
+{
+  return wsize;
+}
+
+/* pointer to beginning of stream */
+inline_ void*
+stream_data(const bitstream* s)
+{
+  return s->begin;
+}
+
+/* current byte size of stream (if flushed) */
+inline_ size_t
+stream_size(const bitstream* s)
+{
+  return (size_t)(s->ptr - s->begin) * sizeof(bitstream_word);
+}
+
+/* byte capacity of stream */
+inline_ size_t
+stream_capacity(const bitstream* s)
+{
+  return (size_t)(s->end - s->begin) * sizeof(bitstream_word);
+}
+
+/* number of words per block */
+inline_ size_t
+stream_stride_block(const bitstream* s)
+{
+#ifdef BIT_STREAM_STRIDED
+  return s->mask + 1;
+#else
+  unused_(s);
+  return 1;
+#endif
+}
+
+/* number of blocks between consecutive stream blocks */
+inline_ ptrdiff_t
+stream_stride_delta(const bitstream* s)
+{
+#ifdef BIT_STREAM_STRIDED
+  return s->delta / (s->mask + 1);
+#else
+  unused_(s);
+  return 0;
+#endif
+}
+
+/* read single bit (0 or 1) */
+inline_ uint
+stream_read_bit(bitstream* s)
+{
+  uint bit;
+  if (!s->bits) {
+    s->buffer = stream_read_word(s);
+    s->bits = wsize;
+  }
+  s->bits--;
+  bit = (uint)s->buffer & 1u;
+  s->buffer >>= 1;
+  return bit;
+}
+
+/* write single bit (must be 0 or 1) */
+inline_ uint
+stream_write_bit(bitstream* s, uint bit)
+{
+  s->buffer += (bitstream_word)bit << s->bits;
+  if (++s->bits == wsize) {
+    stream_write_word(s, s->buffer);
+    s->buffer = 0;
+    s->bits = 0;
+  }
+  return bit;
+}
+
+/* read 0 <= n <= 64 bits */
+inline_ uint64
+stream_read_bits(bitstream* s, bitstream_count n)
+{
+  uint64 value = s->buffer;
+  if (s->bits < n) {
+    /* keep fetching wsize bits until enough bits are buffered */
+    do {
+      /* assert: 0 <= s->bits < n <= 64 */
+      s->buffer = stream_read_word(s);
+      value += (uint64)s->buffer << s->bits;
+      s->bits += wsize;
+    } while (sizeof(s->buffer) < sizeof(value) && s->bits < n);
+    /* assert: 1 <= n <= s->bits < n + wsize */
+    s->bits -= n;
+    if (!s->bits) {
+      /* value holds exactly n bits; no need for masking */
+      s->buffer = 0;
+    }
+    else {
+      /* assert: 1 <= s->bits < wsize */
+      s->buffer >>= wsize - s->bits;
+      /* assert: 1 <= n <= 64 */
+      value &= ((uint64)2 << (n - 1)) - 1;
+    }
+  }
+  else {
+    /* assert: 0 <= n <= s->bits < wsize <= 64 */
+    s->bits -= n;
+    s->buffer >>= n;
+    value &= ((uint64)1 << n) - 1;
+  }
+  return value;
+}
+
+/* write 0 <= n <= 64 low bits of value and return remaining bits */
+inline_ uint64
+stream_write_bits(bitstream* s, uint64 value, bitstream_count n)
+{
+  /* append bit string to buffer */
+  s->buffer += (bitstream_word)(value << s->bits);
+  s->bits += n;
+  /* is buffer full? */
+  if (s->bits >= wsize) {
+    /* 1 <= n <= 64; decrement n to ensure valid right shifts below */
+    value >>= 1;
+    n--;
+    /* assert: 0 <= n < 64; wsize <= s->bits <= wsize + n */
+    do {
+      /* output wsize bits while buffer is full */
+      s->bits -= wsize;
+      /* assert: 0 <= s->bits <= n */
+      stream_write_word(s, s->buffer);
+      /* assert: 0 <= n - s->bits < 64 */
+      s->buffer = (bitstream_word)(value >> (n - s->bits));
+    } while (sizeof(s->buffer) < sizeof(value) && s->bits >= wsize);
+  }
+  /* assert: 0 <= s->bits < wsize */
+  s->buffer &= ((bitstream_word)1 << s->bits) - 1;
+  /* assert: 0 <= n < 64 */
+  return value >> n;
+}
+
+/* return bit offset to next bit to be read */
+inline_ bitstream_offset
+stream_rtell(const bitstream* s)
+{
+  return (bitstream_offset)(s->ptr - s->begin) * wsize - s->bits;
+}
+
+/* return bit offset to next bit to be written */
+inline_ bitstream_offset
+stream_wtell(const bitstream* s)
+{
+  return (bitstream_offset)(s->ptr - s->begin) * wsize + s->bits;
+}
+
+/* position stream for reading or writing at beginning */
+inline_ void
+stream_rewind(bitstream* s)
+{
+  s->ptr = s->begin;
+  s->buffer = 0;
+  s->bits = 0;
+}
+
+/* position stream for reading at given bit offset */
+inline_ void
+stream_rseek(bitstream* s, bitstream_offset offset)
+{
+  bitstream_count n = (bitstream_count)(offset % wsize);
+  s->ptr = s->begin + (size_t)(offset / wsize);
+  if (n) {
+    s->buffer = stream_read_word(s) >> n;
+    s->bits = wsize - n;
+  }
+  else {
+    s->buffer = 0;
+    s->bits = 0;
+  }
+}
+
+/* position stream for writing at given bit offset */
+inline_ void
+stream_wseek(bitstream* s, bitstream_offset offset)
+{
+  bitstream_count n = (bitstream_count)(offset % wsize);
+  s->ptr = s->begin + (size_t)(offset / wsize);
+  if (n) {
+    bitstream_word buffer = *s->ptr;
+    buffer &= ((bitstream_word)1 << n) - 1;
+    s->buffer = buffer;
+    s->bits = n;
+  }
+  else {
+    s->buffer = 0;
+    s->bits = 0;
+  }
+}
+
+/* skip over the next n bits (n >= 0) */
+inline_ void
+stream_skip(bitstream* s, bitstream_size n)
+{
+  stream_rseek(s, stream_rtell(s) + n);
+}
+
+/* append n zero-bits to stream (n >= 0) */
+inline_ void
+stream_pad(bitstream* s, bitstream_size n)
+{
+  bitstream_offset bits = s->bits;
+  for (bits += n; bits >= wsize; bits -= wsize) {
+    stream_write_word(s, s->buffer);
+    s->buffer = 0;
+  }
+  s->bits = (bitstream_count)bits;
+}
+
+/* align stream on next word boundary */
+inline_ bitstream_count
+stream_align(bitstream* s)
+{
+  bitstream_count bits = s->bits;
+  if (bits)
+    stream_skip(s, bits);
+  return bits;
+}
+
+/* write any remaining buffered bits and align stream on next word boundary */
+inline_ bitstream_count
+stream_flush(bitstream* s)
+{
+  bitstream_count bits = (wsize - s->bits) % wsize;
+  if (bits)
+    stream_pad(s, bits);
+  return bits;
+}
+
+/* copy n bits from one bit stream to another */
+inline_ void
+stream_copy(bitstream* dst, bitstream* src, bitstream_size n)
+{
+  while (n > wsize) {
+    bitstream_word w = (bitstream_word)stream_read_bits(src, wsize);
+    stream_write_bits(dst, w, wsize);
+    n -= wsize;
+  }
+  if (n) {
+    bitstream_word w = (bitstream_word)stream_read_bits(src, (bitstream_count)n);
+    stream_write_bits(dst, w, (bitstream_count)n);
+  }
+}
+
+#ifdef BIT_STREAM_STRIDED
+/* set block size in number of words and spacing in number of blocks */
+inline_ int
+stream_set_stride(bitstream* s, size_t block, ptrdiff_t delta)
+{
+  /* ensure block size is a power of two */
+  if (block & (block - 1))
+    return 0;
+  s->mask = block - 1;
+  s->delta = delta * block;
+  return 1;
+}
+#endif
+
+/* allocate and initialize bit stream to user-allocated buffer */
+inline_ bitstream*
+stream_open(void* buffer, size_t bytes)
+{
+  bitstream* s = (bitstream*)std::malloc(sizeof(bitstream));  // sam added std
+  if (s) {
+    s->begin = (bitstream_word*)buffer;
+    s->end = s->begin + bytes / sizeof(bitstream_word);
+#ifdef BIT_STREAM_STRIDED
+    stream_set_stride(s, 0, 0);
+#endif
+    stream_rewind(s);
+  }
+  return s;
+}
+
+/* close and deallocate bit stream */
+inline_ void
+stream_close(bitstream* s)
+{
+  std::free(s);  // sam added std
+}
+
+/* make a copy of bit stream to shared memory buffer */
+inline_ bitstream*
+stream_clone(const bitstream* s)
+{
+  bitstream* c = (bitstream*)std::malloc(sizeof(bitstream));  // sam added std
+  if (c)
+    *c = *s;
+  return c;
+}
+
+// Sam addition: test if a range contains at least one "1" bit
+inline_ uint
+stream_test_range(bitstream* s, bitstream_offset start_pos, bitstream_offset range_len)
+{
+  stream_rseek(s, start_pos);
+
+  /* step 1: test the buffered word */
+  const bitstream_count buf_bit_num = s->bits;
+  uint64 value = 0ul;
+  if (buf_bit_num < range_len)
+    value = stream_read_bits(s, buf_bit_num);
+  else
+    value = stream_read_bits(s, range_len); 
+  if (value != 0ul) {
+    return 1u;
+  }
+
+  /* step 2: test the whole integers */
+  const bitstream_count no_buf_bit_num = range_len > buf_bit_num ? range_len - buf_bit_num : 0;
+  const bitstream_count whole_int_num = no_buf_bit_num / wsize;
+  bitstream_count idx = 0;
+  for (idx = 0; idx < whole_int_num; idx++) {
+    if (stream_read_word(s) != 0u)
+      return 1u;
+  }
+
+  /* step 3: test the remaining bits */
+  const bitstream_count remaining_bit_num = no_buf_bit_num % wsize;
+  value = stream_read_bits(s, remaining_bit_num);
+  return (value != 0ul ? 1u : 0u);
+}
+// Finish Sam addition
+
+#undef unused_
+
+};  // namespace zfp

--- a/include/bitstream.inl
+++ b/include/bitstream.inl
@@ -105,6 +105,10 @@ The following assumptions and restrictions apply:
    caught.
 */
 
+// This file is from ZFP (https://github.com/LLNL/zfp/blob/develop/include/zfp/bitstream.inl)
+// It is based on commit b2366c0 on Jul 6, 2022.
+// All changes from the ZFP repo are denoted by Sam.
+
 #include <climits>  // sam
 #include <cstddef>  // sam
 #include <cstdint>  // sam
@@ -516,4 +520,4 @@ stream_test_range(bitstream* s, bitstream_offset start_pos, bitstream_offset ran
 
 #undef unused_
 
-};  // namespace zfp
+};  // sam: namespace zfp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,6 +54,8 @@ set_target_properties( SPERR PROPERTIES VERSION ${SPERR_VERSION} )
 #
 set( public_h_list 
 "include/sperr_helper.h;\
+include/bitstream.inl\
+include/ZFP_bitstream.h\
 include/Conditioner.h;\
 include/Base_Filter.h;\
 include/CDF97.h;\

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library( SPERR
              sperr_helper.cpp
+             ZFP_bitstream.cpp
              Conditioner.cpp
              Base_Filter.cpp
              CDF97.cpp

--- a/src/ZFP_bitstream.cpp
+++ b/src/ZFP_bitstream.cpp
@@ -25,7 +25,7 @@ auto sperr::ZFP_bitstream::capacity() const -> size_t
   return m_capacity;
 }
 
-// Functions for read 
+// Functions for read
 auto sperr::ZFP_bitstream::rtell() const -> size_t
 {
   return zfp::stream_rtell(m_handle.get());
@@ -42,7 +42,7 @@ auto sperr::ZFP_bitstream::wtell() const -> size_t
   return zfp::stream_wtell(m_handle.get());
 }
 
-void sperr::ZFP_bitstream::wseek(size_t offset) 
+void sperr::ZFP_bitstream::wseek(size_t offset)
 {
   return zfp::stream_wseek(m_handle.get(), offset);
 }

--- a/src/ZFP_bitstream.cpp
+++ b/src/ZFP_bitstream.cpp
@@ -1,0 +1,66 @@
+#include "ZFP_bitstream.h"
+
+// Constructor
+sperr::ZFP_bitstream::ZFP_bitstream(size_t nbits)
+{
+  // Number of longs that's absolutely needed.
+  auto num_of_longs = nbits / 64;
+  if (nbits % 64 != 0)
+    num_of_longs++;
+
+  m_buf.resize(num_of_longs);
+  m_capacity = num_of_longs * 64;
+
+  m_handle.reset(zfp::stream_open(m_buf.data(), m_buf.size() * sizeof(uint64_t)));
+}
+
+// Functions for both read and write
+void sperr::ZFP_bitstream::rewind()
+{
+  return zfp::stream_rewind(m_handle.get());
+}
+
+auto sperr::ZFP_bitstream::capacity() const -> size_t
+{
+  return m_capacity;
+}
+
+// Functions for read 
+auto sperr::ZFP_bitstream::rtell() const -> size_t
+{
+  return zfp::stream_rtell(m_handle.get());
+}
+
+void sperr::ZFP_bitstream::rseek(size_t offset)
+{
+  zfp::stream_rseek(m_handle.get(), offset);
+}
+
+// Functions for write
+auto sperr::ZFP_bitstream::wtell() const -> size_t
+{
+  return zfp::stream_wtell(m_handle.get());
+}
+
+void sperr::ZFP_bitstream::wseek(size_t offset) 
+{
+  return zfp::stream_wseek(m_handle.get(), offset);
+}
+
+auto sperr::ZFP_bitstream::flush() -> size_t
+{
+  return zfp::stream_flush(m_handle.get());
+}
+
+void sperr::ZFP_bitstream::m_wgrow_buf()
+{
+  const auto curr_pos = zfp::stream_wtell(m_handle.get());
+  zfp::stream_flush(m_handle.get());
+
+  m_buf.push_back(0ul);
+  m_buf.resize(m_buf.capacity());
+  m_capacity = m_buf.size() * 64;
+  m_handle.reset(zfp::stream_open(m_buf.data(), m_buf.size() * sizeof(uint64_t)));
+
+  zfp::stream_wseek(m_handle.get(), curr_pos);
+}

--- a/test_scripts/CMakeLists.txt
+++ b/test_scripts/CMakeLists.txt
@@ -1,6 +1,9 @@
 add_executable(        sperr_helper sperr_helper_unit_test.cpp )
 target_link_libraries( sperr_helper PUBLIC SPERR gtest_main )
 
+add_executable(        bitstream bitstream_unit_test.cpp )
+target_link_libraries( bitstream PUBLIC SPERR gtest_main )
+
 add_executable(        dwt dwt_unit_test.cpp )
 target_link_libraries( dwt PUBLIC SPERR gtest_main )
 
@@ -15,6 +18,7 @@ target_link_libraries( sperr PUBLIC SPERR gtest_main )
 
 include(GoogleTest)
 gtest_discover_tests( sperr_helper )
+gtest_discover_tests( bitstream )
 gtest_discover_tests( dwt     )
 gtest_discover_tests( sperr2d )
 gtest_discover_tests( sperr3d )

--- a/test_scripts/bitstream_unit_test.cpp
+++ b/test_scripts/bitstream_unit_test.cpp
@@ -1,0 +1,183 @@
+#include "gtest/gtest.h"
+
+#include "ZFP_bitstream.h"
+
+#include <vector>
+#include <random>
+
+namespace {
+
+using Stream = sperr::ZFP_bitstream;
+
+TEST(ZFP_bitstream, constructor)
+{
+  auto s1 = Stream();
+  EXPECT_EQ(s1.capacity(), 1024);
+
+  auto s2 = Stream(1024 + 1);
+  EXPECT_EQ(s2.capacity(), 1024 + 64);
+
+  auto s3 = Stream(1024 + 63);
+  EXPECT_EQ(s3.capacity(), 1024 + 64);
+
+  auto s4 = Stream(1024 + 64);
+  EXPECT_EQ(s4.capacity(), 1024 + 64);
+
+  auto s5 = Stream(1024 + 65);
+  EXPECT_EQ(s5.capacity(), 1024 + 64 * 2);
+
+  auto s6 = Stream(1024 - 1);
+  EXPECT_EQ(s6.capacity(), 1024);
+
+  auto s7 = Stream(1024 - 63);
+  EXPECT_EQ(s7.capacity(), 1024);
+
+  auto s8 = Stream(1024 - 64);
+  EXPECT_EQ(s8.capacity(), 1024 - 64);
+
+  auto s9 = Stream(1024 - 65);
+  EXPECT_EQ(s9.capacity(), 1024 - 64);
+}
+
+TEST(ZFP_bitstream, MemoryAllocation1)
+{
+  auto s1 = Stream(64);
+  auto vec = std::vector<bool>();
+
+  std::random_device rd;   // Will be used to obtain a seed for the random number engine
+  std::mt19937 gen(rd());  // Standard mersenne_twister_engine seeded with rd()
+  std::uniform_int_distribution<unsigned int> distrib(0, 1);
+
+  s1.rewind();
+  for (size_t i = 0; i < 64; i++) {
+    auto val = distrib(gen);
+    s1.write_bit(val);
+    vec.push_back(val);
+  }
+  EXPECT_EQ(s1.capacity(), 64);
+
+  // Write another bit; the capacity is expected to grow to 128.
+  s1.write_bit(1);
+  vec.push_back(1);
+  EXPECT_EQ(s1.capacity(), 128);
+
+  // All saved bits should be correct too.
+  EXPECT_EQ(s1.wtell(), 65);
+  s1.flush();
+  s1.rewind();
+  for (size_t i = 0; i < vec.size(); i++)
+    EXPECT_EQ(s1.read_bit(), vec[i]) << "at idx = " << i;
+
+  // Let's try to trigger another memory re-allocation
+  s1.wseek(65);
+  for (size_t i = 0; i < 64; i++) {
+    auto val = distrib(gen);
+    s1.write_bit(val);
+    vec.push_back(val);
+  }
+  EXPECT_EQ(s1.capacity(), 256);
+  EXPECT_EQ(s1.wtell(), 129);
+  s1.flush();
+  s1.rewind();
+  for (size_t i = 0; i < vec.size(); i++)
+    EXPECT_EQ(s1.read_bit(), vec[i]) << "at idx = " << i;
+}
+
+TEST(ZFP_bitstream, MemoryAllocation2)
+{
+  auto s1 = Stream(130);
+  EXPECT_EQ(s1.capacity(), 192);
+
+  s1.write_n_bits(928798ul, 64);
+  s1.write_n_bits(9845932ul, 64);
+  s1.write_n_bits(19821ul, 63);
+  EXPECT_EQ(s1.wtell(), 191);
+  EXPECT_EQ(s1.capacity(), 192);
+
+  s1.write_n_bits(8219821ul, 63);
+  EXPECT_TRUE(s1.capacity() == 256 || s1.capacity() == 384);
+
+  // Let's try one more time!
+  s1.rewind();
+  auto vec = std::vector<bool>();
+  std::random_device rd;   // Will be used to obtain a seed for the random number engine
+  std::mt19937 gen(rd());  // Standard mersenne_twister_engine seeded with rd()
+  std::uniform_int_distribution<unsigned int> distrib(0, 1);
+  for (size_t itr = 0; itr < 4; itr++) {
+    uint64_t value = 0ul;
+    for(size_t i = 0; i < 64; i++) {
+      uint64_t ran = distrib(gen);
+      value += ran << i;
+      vec.push_back(ran);
+    }
+    s1.write_n_bits(value, 64);
+  }
+  EXPECT_EQ(s1.wtell(), vec.size());
+  EXPECT_TRUE(s1.capacity() == 256 || s1.capacity() == 384);
+  s1.rewind();
+  for (size_t i = 0; i < vec.size(); i++)
+    EXPECT_EQ(s1.read_bit(), vec[i]) << "at idx = " << i;
+
+  s1.wseek(vec.size());
+  for (size_t itr = 0; itr < 3; itr++) {
+    uint64_t value = 0ul;
+    for(size_t i = 0; i < 63; i++) {
+      uint64_t ran = distrib(gen);
+      value += ran << i;
+      vec.push_back(ran);
+    }
+    s1.write_n_bits(value, 63);
+  }
+  EXPECT_EQ(s1.wtell(), vec.size());
+  EXPECT_TRUE(s1.capacity() == 512 || s1.capacity() == 768);
+  s1.flush();
+  s1.rewind();
+  for (size_t i = 0; i < vec.size(); i++)
+    EXPECT_EQ(s1.read_bit(), vec[i]) << "at idx = " << i;
+}
+
+TEST(ZFP_bitstream, TestRange)
+{
+  auto s1 = Stream(19);
+
+  // Test buffered word
+  s1.write_n_bits(0ul, 63);
+  s1.write_bit(true);
+  s1.flush();
+  EXPECT_EQ(s1.test_range(2, 45), false);
+  EXPECT_EQ(s1.test_range(2, 62), true);
+
+  // Test whole integers
+  s1.rewind();
+  for (size_t i = 0; i < 3; i++)
+    s1.write_n_bits(0ul, 63);
+  s1.write_bit(true);
+  s1.write_bit(false);
+  s1.write_bit(false);
+  EXPECT_EQ(s1.wtell(), 192);
+  s1.flush(); 
+  EXPECT_EQ(s1.test_range(0, 63), false);
+  EXPECT_EQ(s1.test_range(63, 63), false);
+  EXPECT_EQ(s1.test_range(126, 63), false);
+  EXPECT_EQ(s1.test_range(0, 64), false);
+  EXPECT_EQ(s1.test_range(64, 64), false);
+  EXPECT_EQ(s1.test_range(128, 61), false);
+  EXPECT_EQ(s1.test_range(64, 125), false);
+  EXPECT_EQ(s1.test_range(64, 126), true);
+  EXPECT_EQ(s1.test_range(63, 127), true);
+  EXPECT_EQ(s1.test_range(62, 129), true);
+
+  // Test remaining bits
+  s1.rewind();
+  for (size_t i = 0; i < 3; i++)
+    s1.write_n_bits(0ul, 64);
+  s1.write_bit(true);
+  s1.flush();
+  EXPECT_EQ(s1.test_range(0, 192), false);
+  EXPECT_EQ(s1.test_range(1, 192), true);
+  EXPECT_EQ(s1.test_range(2, 191), true);
+  EXPECT_EQ(s1.test_range(3, 190), true);
+  EXPECT_EQ(s1.test_range(3, 189), false);
+}
+
+}

--- a/test_scripts/bitstream_unit_test.cpp
+++ b/test_scripts/bitstream_unit_test.cpp
@@ -2,8 +2,8 @@
 
 #include "ZFP_bitstream.h"
 
-#include <vector>
 #include <random>
+#include <vector>
 
 namespace {
 
@@ -105,7 +105,7 @@ TEST(ZFP_bitstream, MemoryAllocation2)
   std::uniform_int_distribution<unsigned int> distrib(0, 1);
   for (size_t itr = 0; itr < 4; itr++) {
     uint64_t value = 0ul;
-    for(size_t i = 0; i < 64; i++) {
+    for (size_t i = 0; i < 64; i++) {
       uint64_t ran = distrib(gen);
       value += ran << i;
       vec.push_back(ran);
@@ -121,7 +121,7 @@ TEST(ZFP_bitstream, MemoryAllocation2)
   s1.wseek(vec.size());
   for (size_t itr = 0; itr < 3; itr++) {
     uint64_t value = 0ul;
-    for(size_t i = 0; i < 63; i++) {
+    for (size_t i = 0; i < 63; i++) {
       uint64_t ran = distrib(gen);
       value += ran << i;
       vec.push_back(ran);
@@ -155,7 +155,7 @@ TEST(ZFP_bitstream, TestRange)
   s1.write_bit(false);
   s1.write_bit(false);
   EXPECT_EQ(s1.wtell(), 192);
-  s1.flush(); 
+  s1.flush();
   EXPECT_EQ(s1.test_range(0, 63), false);
   EXPECT_EQ(s1.test_range(63, 63), false);
   EXPECT_EQ(s1.test_range(126, 63), false);
@@ -180,4 +180,4 @@ TEST(ZFP_bitstream, TestRange)
   EXPECT_EQ(s1.test_range(3, 189), false);
 }
 
-}
+}  // namespace


### PR DESCRIPTION
This PR introduces `ZFP_bitstream` class, which is likely much more performant than `std::vector<bool>`. This PR will help issue #189  and #190 .

This PR doesn't put `ZFP_bitstream` in use anywhere of the coding/decoding algorithms though. 