### PR TITLE
Enforce vecd_type

### DIFF
--- a/include/CDF97.h
+++ b/include/CDF97.h
@@ -26,13 +26,13 @@ class CDF97 {
   // Note that copy_data() and take_data() effectively resets internal states of this class.
   template <typename T>
   auto copy_data(const T* buf, size_t len, dims_type dims) -> RTNType;
-  auto take_data(std::vector<double>&& buf, dims_type dims) -> RTNType;
+  auto take_data(vecd_type&& buf, dims_type dims) -> RTNType;
 
   //
   // Output
   //
-  auto view_data() const -> const std::vector<double>&;
-  auto release_data() -> std::vector<double>&&;
+  auto view_data() const -> const vecd_type&;
+  auto release_data() -> vecd_type&&;
   auto get_dims() const -> std::array<size_t, 3>;  // In 2D case, the 3rd value equals 1.
 
   // Action items

--- a/include/Conditioner.h
+++ b/include/Conditioner.h
@@ -49,7 +49,7 @@ class Conditioner {
   // Calculations are carried out by strides, which
   // should be a divisor of the input data size.
   size_t m_num_strides = m_default_num_strides;
-  std::vector<double> m_stride_buf;
+  vecd_type m_stride_buf;
   // Adjust the value of `m_num_strides` so it'll be a divisor of `len`.
   void m_adjust_strides(size_t len);
   // Reset meta fields

--- a/include/SPECK_Storage.h
+++ b/include/SPECK_Storage.h
@@ -63,14 +63,14 @@ class SPECK_Storage {
 
   // Data storage shared by both 2D and 3D SPECK.
   //
-  vecd_type m_coeff_buf;            // Wavelet coefficients
-  std::vector<bool> m_bit_buffer;   // Bitstream produced by the algorithm
-  std::vector<size_t> m_LIP;        // List of insignificant pixels
-  std::vector<size_t> m_LSP_new;    // List of newly found significant pixels
-  std::vector<bool> m_LSP_mask;     // Significant pixels previously found
-  std::vector<bool> m_sign_array;   // Keep the signs of every coefficient
-  vec8_type m_encoded_stream;       // Stores the SPECK bitstream
-  dims_type m_dims = {0, 0, 0};     // Dimension of the 2D/3D volume
+  vecd_type m_coeff_buf;           // Wavelet coefficients
+  std::vector<bool> m_bit_buffer;  // Bitstream produced by the algorithm
+  std::vector<size_t> m_LIP;       // List of insignificant pixels
+  std::vector<size_t> m_LSP_new;   // List of newly found significant pixels
+  std::vector<bool> m_LSP_mask;    // Significant pixels previously found
+  std::vector<bool> m_sign_array;  // Keep the signs of every coefficient
+  vec8_type m_encoded_stream;      // Stores the SPECK bitstream
+  dims_type m_dims = {0, 0, 0};    // Dimension of the 2D/3D volume
 
   // In fixed-pwe mode, keep track of would-be quantized coefficient values.
   // These values are reconstructed exactly the same way as if during decompression.

--- a/include/SPECK_Storage.h
+++ b/include/SPECK_Storage.h
@@ -63,7 +63,7 @@ class SPECK_Storage {
 
   // Data storage shared by both 2D and 3D SPECK.
   //
-  std::vector<double> m_coeff_buf;  // Wavelet coefficients
+  vecd_type m_coeff_buf;            // Wavelet coefficients
   std::vector<bool> m_bit_buffer;   // Bitstream produced by the algorithm
   std::vector<size_t> m_LIP;        // List of insignificant pixels
   std::vector<size_t> m_LSP_new;    // List of newly found significant pixels
@@ -75,7 +75,7 @@ class SPECK_Storage {
   // In fixed-pwe mode, keep track of would-be quantized coefficient values.
   // These values are reconstructed exactly the same way as if during decompression.
   // Other mathematically equivalent methods would however not give the same values.
-  std::vector<double> m_qz_coeff;
+  vecd_type m_qz_coeff;
 
   //
   // Member methods

--- a/include/SPERR.h
+++ b/include/SPERR.h
@@ -100,7 +100,7 @@ class SPERR {
   size_t m_num_itrs = 0;      // encoding only. Number of iterations.
 
   std::vector<bool> m_bit_buffer;
-  std::vector<double> m_q;     // encoding only. This list is refined in the refinement pass.
+  vecd_type m_q;               // encoding only. This list is refined in the refinement pass.
   std::vector<Outlier> m_LOS;  // List of OutlierS. This list is not altered when encoding,
                                // but constantly updated when decoding.
 

--- a/include/SPERR2D_Compressor.h
+++ b/include/SPERR2D_Compressor.h
@@ -23,7 +23,7 @@ class SPERR2D_Compressor {
       -> RTNType;
 
   // Accept incoming data by taking ownership of the memory block
-  auto take_data(std::vector<double>&& buf, sperr::dims_type dims) -> RTNType;
+  auto take_data(sperr::vecd_type&& buf, sperr::dims_type dims) -> RTNType;
 
   auto set_target_bpp(double) -> RTNType;
   void set_target_psnr(double);

--- a/include/SPERR2D_Decompressor.h
+++ b/include/SPERR2D_Decompressor.h
@@ -24,8 +24,8 @@ class SPERR2D_Decompressor {
   // Get the decompressed data in a float or double buffer.
   template <typename T>
   auto get_data() const -> std::vector<T>;
-  auto release_data() -> std::vector<double>&&;
-  auto view_data() const -> const std::vector<double>&;
+  auto release_data() -> sperr::vecd_type&&;
+  auto view_data() const -> const sperr::vecd_type&;
   auto get_dims() const -> sperr::dims_type;
 
  private:

--- a/include/SPERR3D_Compressor.h
+++ b/include/SPERR3D_Compressor.h
@@ -22,7 +22,7 @@ class SPERR3D_Compressor {
       -> RTNType;
 
   // Accept incoming data: take ownership of a memory block
-  auto take_data(std::vector<double>&& buf, dims_type dims) -> RTNType;
+  auto take_data(sperr::vecd_type&& buf, dims_type dims) -> RTNType;
 
   auto set_comp_params(size_t bit_budget, double psnr, double pwe) -> RTNType;
 

--- a/include/SPERR3D_Decompressor.h
+++ b/include/SPERR3D_Decompressor.h
@@ -30,8 +30,8 @@ class SPERR3D_Decompressor {
   // Get the decompressed volume in a float or double buffer.
   template <typename T>
   auto get_data() const -> std::vector<T>;
-  auto view_data() const -> const std::vector<double>&;
-  auto release_data() -> std::vector<double>&&;
+  auto view_data() const -> const sperr::vecd_type&;
+  auto release_data() -> sperr::vecd_type&&;
 
  private:
   dims_type m_dims = {0, 0, 0};

--- a/include/SPERR3D_OMP_D.h
+++ b/include/SPERR3D_OMP_D.h
@@ -23,8 +23,8 @@ class SPERR3D_OMP_D {
   // The pointer passed in here MUST be the same as the one passed to `use_bitstream()`.
   auto decompress(const void*) -> RTNType;
 
-  auto release_data() -> std::vector<double>&&;
-  auto view_data() const -> const std::vector<double>&;
+  auto release_data() -> sperr::vecd_type&&;
+  auto view_data() const -> const sperr::vecd_type&;
   template <typename T>
   auto get_data() const -> std::vector<T>;
   auto get_dims() const -> sperr::dims_type;
@@ -38,7 +38,7 @@ class SPERR3D_OMP_D {
   const size_t m_header_magic_nchunks = 26;
   const size_t m_header_magic_1chunk = 14;
 
-  std::vector<double> m_vol_buf;
+  sperr::vecd_type m_vol_buf;
   std::vector<size_t> m_offsets;
   const uint8_t* m_bitstream_ptr = nullptr;
 };

--- a/include/sperr_helper.h
+++ b/include/sperr_helper.h
@@ -31,9 +31,11 @@ constexpr auto max_d = std::numeric_limits<double>::max();
 //
 // A few shortcuts
 //
-using vecf_type = std::vector<float>;
-using vecd_type = std::vector<double>;
-using vec8_type = std::vector<uint8_t>;
+template <typename T>
+using vec_type = std::vector<T>;
+using vecf_type = vec_type<float>;
+using vecd_type = vec_type<double>;
+using vec8_type = vec_type<uint8_t>;
 using dims_type = std::array<size_t, 3>;
 
 //
@@ -112,11 +114,11 @@ auto unpack_8_booleans(uint8_t) -> std::array<bool, 8>;
 // Note: not using references for `filename` to allow a c-style string literal to be passed in.
 auto write_n_bytes(std::string filename, size_t n_bytes, const void* buffer) -> RTNType;
 template <typename T>
-auto read_whole_file(std::string filename) -> std::vector<T>;
+auto read_whole_file(std::string filename) -> vec_type<T>;
 
 // Upon success, it returns a vector of size `n_bytes`.
 // Otherwise, it returns an empty vector.
-auto read_n_bytes(std::string filename, size_t n_bytes) -> std::vector<uint8_t>;
+auto read_n_bytes(std::string filename, size_t n_bytes) -> vec8_type;
 
 // Calculate a suite of statistics.
 // Note that arr1 is considered as the ground truth array, so it's the range of
@@ -151,15 +153,15 @@ auto chunk_volume(const dims_type& vol_dim, const dims_type& chunk_dim)
 // this function returns an empty vector.
 template <typename T1, typename T2>
 auto gather_chunk(const T1* vol, dims_type vol_dim, const std::array<size_t, 6>& chunk)
-    -> std::vector<T2>;
+    -> vec_type<T2>;
 
 // Put this chunk to a bigger volume
 // The `big_vol` should have enough space allocated, and the `small_vol` should contain
 // enough elements to scatter. Memory errors will occur if the conditions are not met.
 template <typename TBIG, typename TSML>
-void scatter_chunk(std::vector<TBIG>& big_vol,
+void scatter_chunk(vec_type<TBIG>& big_vol,
                    dims_type vol_dim,
-                   const std::vector<TSML>& small_vol,
+                   const vec_type<TSML>& small_vol,
                    const std::array<size_t, 6>& chunk);
 
 // Structure that holds information extracted from SPERR headers.

--- a/src/SPERR2D_Compressor.cpp
+++ b/src/SPERR2D_Compressor.cpp
@@ -30,7 +30,7 @@ auto SPERR2D_Compressor::copy_data(const T* p, size_t len, sperr::dims_type dims
 template auto SPERR2D_Compressor::copy_data(const double*, size_t, sperr::dims_type) -> RTNType;
 template auto SPERR2D_Compressor::copy_data(const float*, size_t, sperr::dims_type) -> RTNType;
 
-auto SPERR2D_Compressor::take_data(std::vector<double>&& buf, sperr::dims_type dims) -> RTNType
+auto SPERR2D_Compressor::take_data(sperr::vecd_type&& buf, sperr::dims_type dims) -> RTNType
 {
   if (buf.size() != dims[0] * dims[1] || dims[2] != 1)
     return RTNType::WrongDims;

--- a/src/SPERR2D_Decompressor.cpp
+++ b/src/SPERR2D_Decompressor.cpp
@@ -125,15 +125,15 @@ auto SPERR2D_Decompressor::get_data() const -> std::vector<T>
 
   return out_buf;
 }
-template auto SPERR2D_Decompressor::get_data() const -> std::vector<double>;
-template auto SPERR2D_Decompressor::get_data() const -> std::vector<float>;
+template auto SPERR2D_Decompressor::get_data() const -> sperr::vecd_type;
+template auto SPERR2D_Decompressor::get_data() const -> sperr::vecf_type;
 
-auto SPERR2D_Decompressor::view_data() const -> const std::vector<double>&
+auto SPERR2D_Decompressor::view_data() const -> const sperr::vecd_type&
 {
   return m_val_buf;
 }
 
-auto SPERR2D_Decompressor::release_data() -> std::vector<double>&&
+auto SPERR2D_Decompressor::release_data() -> sperr::vecd_type&&
 {
   m_dims = {0, 0, 0};
   return std::move(m_val_buf);

--- a/src/SPERR3D_Decompressor.cpp
+++ b/src/SPERR3D_Decompressor.cpp
@@ -146,15 +146,15 @@ auto sperr::SPERR3D_Decompressor::get_data() const -> std::vector<T>
 
   return out_buf;
 }
-template auto sperr::SPERR3D_Decompressor::get_data() const -> std::vector<double>;
-template auto sperr::SPERR3D_Decompressor::get_data() const -> std::vector<float>;
+template auto sperr::SPERR3D_Decompressor::get_data() const -> sperr::vecd_type;
+template auto sperr::SPERR3D_Decompressor::get_data() const -> sperr::vecf_type;
 
-auto sperr::SPERR3D_Decompressor::view_data() const -> const std::vector<double>&
+auto sperr::SPERR3D_Decompressor::view_data() const -> const sperr::vecd_type&
 {
   return m_val_buf;
 }
 
-auto sperr::SPERR3D_Decompressor::release_data() -> std::vector<double>&&
+auto sperr::SPERR3D_Decompressor::release_data() -> sperr::vecd_type&&
 {
   m_dims = {0, 0, 0};
   return std::move(m_val_buf);

--- a/src/sperr_helper.cpp
+++ b/src/sperr_helper.cpp
@@ -187,9 +187,9 @@ auto sperr::unpack_8_booleans(uint8_t src) -> std::array<bool, 8>
   return b8;
 }
 
-auto sperr::read_n_bytes(std::string filename, size_t n_bytes) -> std::vector<uint8_t>
+auto sperr::read_n_bytes(std::string filename, size_t n_bytes) -> vec8_type
 {
-  auto buf = std::vector<uint8_t>();
+  auto buf = vec_type<uint8_t>();
 
   std::unique_ptr<std::FILE, decltype(&std::fclose)> fp(std::fopen(filename.data(), "rb"),
                                                         &std::fclose);
@@ -210,9 +210,9 @@ auto sperr::read_n_bytes(std::string filename, size_t n_bytes) -> std::vector<ui
 }
 
 template <typename T>
-auto sperr::read_whole_file(std::string filename) -> std::vector<T>
+auto sperr::read_whole_file(std::string filename) -> vec_type<T>
 {
-  std::vector<T> buf;
+  vec_type<T> buf;
 
   std::unique_ptr<std::FILE, decltype(&std::fclose)> fp(std::fopen(filename.data(), "rb"),
                                                         &std::fclose);
@@ -231,9 +231,9 @@ auto sperr::read_whole_file(std::string filename) -> std::vector<T>
 
   return buf;
 }
-template auto sperr::read_whole_file(std::string) -> std::vector<float>;
-template auto sperr::read_whole_file(std::string) -> std::vector<double>;
-template auto sperr::read_whole_file(std::string) -> std::vector<uint8_t>;
+template auto sperr::read_whole_file(std::string) -> vecf_type;
+template auto sperr::read_whole_file(std::string) -> vecd_type;
+template auto sperr::read_whole_file(std::string) -> vec8_type;
 
 auto sperr::write_n_bytes(std::string filename, size_t n_bytes, const void* buffer) -> RTNType
 {
@@ -284,8 +284,8 @@ auto sperr::calc_stats(const T* arr1, const T* arr2, size_t arr_len, size_t omp_
     return {rmse, linfty, psnr, arr1min, arr1max};
   }
 
-  auto sum_vec = std::vector<T>(num_of_strides + 1);
-  auto linfty_vec = std::vector<T>(num_of_strides + 1);
+  auto sum_vec = vec_type<T>(num_of_strides + 1);
+  auto linfty_vec = vec_type<T>(num_of_strides + 1);
 
 //
 // Calculate diff summation and l-infty of each stride
@@ -414,9 +414,9 @@ auto sperr::chunk_volume(const std::array<size_t, 3>& vol_dim,
 
 template <typename T1, typename T2>
 auto sperr::gather_chunk(const T1* vol, dims_type vol_dim, const std::array<size_t, 6>& chunk)
-    -> std::vector<T2>
+    -> vec_type<T2>
 {
-  auto chunk_buf = std::vector<T2>();
+  auto chunk_buf = vec_type<T2>();
   if (chunk[0] + chunk[1] > vol_dim[0] || chunk[2] + chunk[3] > vol_dim[1] ||
       chunk[4] + chunk[5] > vol_dim[2])
     return chunk_buf;
@@ -446,9 +446,9 @@ template auto sperr::gather_chunk(const double*, dims_type, const std::array<siz
     -> sperr::vecd_type;
 
 template <typename TBIG, typename TSML>
-void sperr::scatter_chunk(std::vector<TBIG>& big_vol,
+void sperr::scatter_chunk(vec_type<TBIG>& big_vol,
                           dims_type vol_dim,
-                          const std::vector<TSML>& small_vol,
+                          const vec_type<TSML>& small_vol,
                           const std::array<size_t, 6>& chunk)
 {
   size_t idx = 0;
@@ -461,21 +461,21 @@ void sperr::scatter_chunk(std::vector<TBIG>& big_vol,
     }
   }
 }
-template void sperr::scatter_chunk(std::vector<float>&,
+template void sperr::scatter_chunk(vec_type<float>&,
                                    dims_type,
-                                   const std::vector<float>&,
+                                   const vec_type<float>&,
                                    const std::array<size_t, 6>&);
-template void sperr::scatter_chunk(std::vector<float>&,
+template void sperr::scatter_chunk(vec_type<float>&,
                                    dims_type,
-                                   const std::vector<double>&,
+                                   const vec_type<double>&,
                                    const std::array<size_t, 6>&);
-template void sperr::scatter_chunk(std::vector<double>&,
+template void sperr::scatter_chunk(vec_type<double>&,
                                    dims_type,
-                                   const std::vector<float>&,
+                                   const vec_type<float>&,
                                    const std::array<size_t, 6>&);
-template void sperr::scatter_chunk(std::vector<double>&,
+template void sperr::scatter_chunk(vec_type<double>&,
                                    dims_type,
-                                   const std::vector<double>&,
+                                   const vec_type<double>&,
                                    const std::array<size_t, 6>&);
 
 auto sperr::parse_header(const void* ptr) -> HeaderInfo
@@ -549,7 +549,7 @@ auto sperr::calc_variance(const T* arr, size_t len, size_t omp_nthreads) -> T
 
   const size_t stride_size = 4096;
   const size_t num_strides = len / stride_size;
-  auto tmp_buf = std::vector<T>(num_strides + 1);
+  auto tmp_buf = vec_type<T>(num_strides + 1);
 
   // First, calculate the mean of this array.
 #pragma omp parallel for num_threads(omp_nthreads)

--- a/src/sperr_helper.cpp
+++ b/src/sperr_helper.cpp
@@ -437,13 +437,13 @@ auto sperr::gather_chunk(const T1* vol, dims_type vol_dim, const std::array<size
   return chunk_buf;
 }
 template auto sperr::gather_chunk(const float*, dims_type, const std::array<size_t, 6>&)
-    -> std::vector<float>;
+    -> sperr::vecf_type;
 template auto sperr::gather_chunk(const float*, dims_type, const std::array<size_t, 6>&)
-    -> std::vector<double>;
+    -> sperr::vecd_type;
 template auto sperr::gather_chunk(const double*, dims_type, const std::array<size_t, 6>&)
-    -> std::vector<float>;
+    -> sperr::vecf_type;
 template auto sperr::gather_chunk(const double*, dims_type, const std::array<size_t, 6>&)
-    -> std::vector<double>;
+    -> sperr::vecd_type;
 
 template <typename TBIG, typename TSML>
 void sperr::scatter_chunk(std::vector<TBIG>& big_vol,

--- a/test_scripts/dwt_unit_test.cpp
+++ b/test_scripts/dwt_unit_test.cpp
@@ -18,7 +18,7 @@ TEST(dwt1d, big_image_even)
   const float* fptr = reinterpret_cast<const float*>(in_buf.data());
 
   // Make a copy and then use a conditioner
-  auto in_copy = std::vector<double>(total_vals);
+  auto in_copy = sperr::vecd_type(total_vals);
   std::copy(fptr, fptr + total_vals, in_copy.begin());
   auto condi = sperr::Conditioner();
   auto meta = condi.condition(in_copy, {dim_x, 1, 1});
@@ -54,7 +54,7 @@ TEST(dwt1d, big_image_odd)
   const float* fptr = reinterpret_cast<const float*>(in_buf.data());
 
   // Make a copy and use a conditioner
-  auto in_copy = std::vector<double>(total_vals);
+  auto in_copy = sperr::vecd_type(total_vals);
   std::copy(fptr, fptr + total_vals, in_copy.begin());
   auto condi = sperr::Conditioner();
   auto meta = condi.condition(in_copy, {dim_x, 1, 1});
@@ -89,7 +89,7 @@ TEST(dwt2d, small_image_even)
     std::cerr << "Input read error!" << std::endl;
 
   // Make a copy and use a conditioner
-  auto in_copy = std::vector<double>(total_vals);
+  auto in_copy = sperr::vecd_type(total_vals);
   std::copy(in_buf.begin(), in_buf.end(), in_copy.begin());
   auto condi = sperr::Conditioner();
   auto meta = condi.condition(in_copy, {dim_x, dim_y, 1});
@@ -124,7 +124,7 @@ TEST(dwt2d, small_image_odd)
     std::cerr << "Input read error!" << std::endl;
 
   // Make a copy and use a conditioner
-  auto in_copy = std::vector<double>(total_vals);
+  auto in_copy = sperr::vecd_type(total_vals);
   std::copy(in_buf.begin(), in_buf.end(), in_copy.begin());
   auto condi = sperr::Conditioner();
   auto meta = condi.condition(in_copy, {dim_x, dim_y, 1});
@@ -159,7 +159,7 @@ TEST(dwt2d, big_image_even)
     std::cerr << "Input read error!" << std::endl;
 
   // Make a copy and use a conditioner
-  auto in_copy = std::vector<double>(total_vals);
+  auto in_copy = sperr::vecd_type(total_vals);
   std::copy(in_buf.begin(), in_buf.end(), in_copy.begin());
   auto condi = sperr::Conditioner();
   auto meta = condi.condition(in_copy, {dim_x, dim_y, 1});
@@ -194,7 +194,7 @@ TEST(dwt2d, big_image_odd)
     std::cerr << "Input read error!" << std::endl;
 
   // Make a copy and use a conditioner
-  auto in_copy = std::vector<double>(total_vals);
+  auto in_copy = sperr::vecd_type(total_vals);
   std::copy(in_buf.begin(), in_buf.end(), in_copy.begin());
   auto condi = sperr::Conditioner();
   auto meta = condi.condition(in_copy, {dim_x, dim_y, 1});
@@ -229,7 +229,7 @@ TEST(dwt3d, small_even_cube)
     std::cerr << "Input read error!" << std::endl;
 
   // Make a copy and use a conditioner
-  auto in_copy = std::vector<double>(total_vals);
+  auto in_copy = sperr::vecd_type(total_vals);
   std::copy(in_buf.begin(), in_buf.end(), in_copy.begin());
   auto condi = sperr::Conditioner();
   auto meta = condi.condition(in_copy, {dim_x, dim_y, dim_z});
@@ -263,7 +263,7 @@ TEST(dwt3d, big_odd_cube)
     std::cerr << "Input read error!" << std::endl;
 
   // Make a copy and use a conditioner
-  auto in_copy = std::vector<double>(total_vals);
+  auto in_copy = sperr::vecd_type(total_vals);
   std::copy(in_buf.begin(), in_buf.end(), in_copy.begin());
   auto condi = sperr::Conditioner();
   auto meta = condi.condition(in_copy, {dim_x, dim_y, dim_z});
@@ -297,7 +297,7 @@ TEST(dwt3d, big_even_cube)
     std::cerr << "Input read error!" << std::endl;
 
   // Make a copy and use a conditioner
-  auto in_copy = std::vector<double>(total_vals);
+  auto in_copy = sperr::vecd_type(total_vals);
   std::copy(in_buf.begin(), in_buf.end(), in_copy.begin());
   auto condi = sperr::Conditioner();
   auto meta = condi.condition(in_copy, {dim_x, dim_y, dim_z});

--- a/utilities/compressor_2d.cpp
+++ b/utilities/compressor_2d.cpp
@@ -185,7 +185,7 @@ int main(int argc, char* argv[])
     if (show_stats) {
       // Make sure that we have a copy of the original data in double precision.
       const double* orig_ptr = nullptr;
-      auto orig_tmp = std::vector<double>();
+      auto orig_tmp = sperr::vecd_type();
       if (use_double)
         orig_ptr = reinterpret_cast<const double*>(orig.data());
       else {

--- a/utilities/compressor_3d.cpp
+++ b/utilities/compressor_3d.cpp
@@ -210,7 +210,7 @@ int main(int argc, char* argv[])
     if (show_stats) {
       // Make sure that we have a copy of the original data in double precision.
       const double* orig_ptr = nullptr;
-      auto orig_tmp = std::vector<double>();
+      auto orig_tmp = sperr::vecd_type();
       if (use_double)
         orig_ptr = reinterpret_cast<const double*>(orig.data());
       else {


### PR DESCRIPTION
This PR simply replaces many occurrences of `std::vector<double>` with `vecd_type`. This PR is supposed to facilitate further effort to use data structures  other than `std::vector<double>`. One of the alternatives being explored right now is `kokkos::vector<double>`. 