### PR TITLE
Const enforcement

### DIFF
--- a/include/CDF97.h
+++ b/include/CDF97.h
@@ -45,7 +45,7 @@ class CDF97 {
 
  private:
   using itd_type = vecd_type::iterator;
-  using citd_type = vecd_type::iterator;
+  using citd_type = vecd_type::const_iterator;
 
   //
   // Private methods helping DWT.

--- a/include/sperr_helper.h
+++ b/include/sperr_helper.h
@@ -145,8 +145,7 @@ auto kahan_summation(const T*, size_t) -> T;
 //         dimension is not exact multiplies of requested chunk dimension,
 //         approximate values are used.
 // Note 2: this function works on degraded 2D or 1D volumes too.
-auto chunk_volume(const dims_type& vol_dim, const dims_type& chunk_dim)
-    -> std::vector<std::array<size_t, 6>>;
+auto chunk_volume(dims_type vol_dim, dims_type chunk_dim) -> std::vector<std::array<size_t, 6>>;
 
 // Gather a chunk from a bigger volume
 // If the requested chunk lives outside of the volume, whole or part,

--- a/src/CDF97.cpp
+++ b/src/CDF97.cpp
@@ -330,11 +330,11 @@ void sperr::CDF97::m_dwt1d_one_level(itd_type array, size_t array_len)
 #endif
   {
     this->QccWAVCDF97AnalysisSymmetricEvenEven(m_qcc_buf.data(), array_len);
-    m_gather_even(m_qcc_buf.begin(), m_qcc_buf.begin() + array_len, array);
+    m_gather_even(m_qcc_buf.cbegin(), m_qcc_buf.cbegin() + array_len, array);
   }
   else {
     this->QccWAVCDF97AnalysisSymmetricOddEven(m_qcc_buf.data(), array_len);
-    m_gather_odd(m_qcc_buf.begin(), m_qcc_buf.begin() + array_len, array);
+    m_gather_odd(m_qcc_buf.cbegin(), m_qcc_buf.cbegin() + array_len, array);
   }
 }
 
@@ -353,7 +353,7 @@ void sperr::CDF97::m_idwt1d_one_level(itd_type array, size_t array_len)
     m_scatter_odd(array, array + array_len, m_qcc_buf.begin());
     this->QccWAVCDF97SynthesisSymmetricOddEven(m_qcc_buf.data(), array_len);
   }
-  std::copy(m_qcc_buf.begin(), m_qcc_buf.begin() + array_len, array);
+  std::copy(m_qcc_buf.cbegin(), m_qcc_buf.cbegin() + array_len, array);
 }
 
 void sperr::CDF97::m_dwt2d_one_level(itd_type plane, std::array<size_t, 2> len_xy)

--- a/src/SPECK2D.cpp
+++ b/src/SPECK2D.cpp
@@ -74,7 +74,7 @@ auto sperr::SPECK2D::encode() -> RTNType
   // Decide the starting threshold for quantization.
   // See `SPECK3D.cpp:encode()` for more discussion on the starting threshold.
   size_t num_bitplanes = 128;
-  const auto max_coeff = *std::max_element(m_coeff_buf.begin(), m_coeff_buf.end());
+  const auto max_coeff = *std::max_element(m_coeff_buf.cbegin(), m_coeff_buf.cend());
   if (m_mode_cache == CompMode::FixedPWE || m_mode_cache == CompMode::FixedPSNR) {
     const auto terminal_threshold = m_estimate_finest_q();
     auto max_t = terminal_threshold;
@@ -586,7 +586,7 @@ auto sperr::SPECK2D::m_decide_set_S_significance(const SPECKSet2D& set) -> SigTy
 
   const auto gtr = [thrd = m_threshold](auto v) { return v >= thrd; };
   for (auto y = set.start_y; y < (set.start_y + set.length_y); y++) {
-    auto first = m_coeff_buf.begin() + y * m_dims[0] + set.start_x;
+    auto first = m_coeff_buf.cbegin() + y * m_dims[0] + set.start_x;
     auto last = first + set.length_x;
     if (std::any_of(first, last, gtr))
       return SigType::Sig;
@@ -602,16 +602,16 @@ auto sperr::SPECK2D::m_decide_set_I_significance(const SPECKSet2D& set) -> SigTy
 
   const auto gtr = [thrd = m_threshold](auto v) { return v >= thrd; };
   for (size_t y = 0; y < set.start_y; y++) {
-    auto first = m_coeff_buf.begin() + y * m_dims[0] + set.start_x;
-    auto last = m_coeff_buf.begin() + (y + 1) * m_dims[0];
+    auto first = m_coeff_buf.cbegin() + y * m_dims[0] + set.start_x;
+    auto last = m_coeff_buf.cbegin() + (y + 1) * m_dims[0];
     if (std::any_of(first, last, gtr))
       return SigType::Sig;
   }
 
   // Second rectangle: the rest area at the bottom
   // Note: this rectangle is stored in a contiguous chunk of memory till the end of the buffer :)
-  auto first = m_coeff_buf.begin() + size_t{set.start_y} * size_t{set.length_x};
-  if (std::any_of(first, m_coeff_buf.end(), gtr))
+  auto first = m_coeff_buf.cbegin() + size_t{set.start_y} * size_t{set.length_x};
+  if (std::any_of(first, m_coeff_buf.cend(), gtr))
     return SigType::Sig;
   else
     return SigType::Insig;

--- a/src/SPECK3D.cpp
+++ b/src/SPECK3D.cpp
@@ -80,7 +80,7 @@ auto sperr::SPECK3D::encode() -> RTNType
 
   // Decide the starting threshold for quantization.
   size_t num_bitplanes = 128;
-  const auto max_coeff = *std::max_element(m_coeff_buf.begin(), m_coeff_buf.end());
+  const auto max_coeff = *std::max_element(m_coeff_buf.cbegin(), m_coeff_buf.cend());
   if (m_mode_cache == CompMode::FixedPWE || m_mode_cache == CompMode::FixedPSNR) {
     const auto terminal_threshold = m_estimate_finest_q();
     auto max_t = terminal_threshold;
@@ -349,7 +349,7 @@ auto sperr::SPECK3D::m_decide_significance(const SPECKSet3D& set) const
   for (auto z = set.start_z; z < (set.start_z + set.length_z); z++) {
     const size_t slice_offset = z * slice_size;
     for (auto y = set.start_y; y < (set.start_y + set.length_y); y++) {
-      auto first = m_coeff_buf.begin() + (slice_offset + y * m_dims[0] + set.start_x);
+      auto first = m_coeff_buf.cbegin() + (slice_offset + y * m_dims[0] + set.start_x);
       auto last = first + set.length_x;
       auto found = std::find_if(first, last, gtr);
       if (found != last) {
@@ -572,7 +572,7 @@ auto sperr::SPECK3D::m_code_S_decode(size_t idx1, size_t idx2) -> RTNType
 
 auto sperr::SPECK3D::m_ready_to_encode() const -> bool
 {
-  if (std::any_of(m_dims.begin(), m_dims.end(), [](auto v) { return v == 0; }))
+  if (std::any_of(m_dims.cbegin(), m_dims.cend(), [](auto v) { return v == 0; }))
     return false;
   if (m_coeff_buf.size() != m_dims[0] * m_dims[1] * m_dims[2])
     return false;
@@ -582,7 +582,7 @@ auto sperr::SPECK3D::m_ready_to_encode() const -> bool
 
 auto sperr::SPECK3D::m_ready_to_decode() const -> bool
 {
-  if (std::any_of(m_dims.begin(), m_dims.end(), [](auto v) { return v == 0; }))
+  if (std::any_of(m_dims.cbegin(), m_dims.cend(), [](auto v) { return v == 0; }))
     return false;
   if (m_bit_buffer.empty())
     return false;

--- a/src/SPECK_Storage.cpp
+++ b/src/SPECK_Storage.cpp
@@ -53,8 +53,8 @@ auto sperr::SPECK_Storage::release_quantized_coeff() -> vecd_type&&
   if (!m_qz_coeff.empty()) {
     assert(m_qz_coeff.size() == m_sign_array.size());
     const auto tmp = d2_type{-1.0, 1.0};
-    std::transform(m_qz_coeff.cbegin(), m_qz_coeff.cend(), m_sign_array.cbegin(), m_qz_coeff.begin(),
-                   [tmp](auto v, auto b) { return v * tmp[b]; });
+    std::transform(m_qz_coeff.cbegin(), m_qz_coeff.cend(), m_sign_array.cbegin(),
+                   m_qz_coeff.begin(), [tmp](auto v, auto b) { return v * tmp[b]; });
   }
 
   return std::move(m_qz_coeff);

--- a/src/SPECK_Storage.cpp
+++ b/src/SPECK_Storage.cpp
@@ -53,7 +53,7 @@ auto sperr::SPECK_Storage::release_quantized_coeff() -> vecd_type&&
   if (!m_qz_coeff.empty()) {
     assert(m_qz_coeff.size() == m_sign_array.size());
     const auto tmp = d2_type{-1.0, 1.0};
-    std::transform(m_qz_coeff.begin(), m_qz_coeff.end(), m_sign_array.cbegin(), m_qz_coeff.begin(),
+    std::transform(m_qz_coeff.cbegin(), m_qz_coeff.cend(), m_sign_array.cbegin(), m_qz_coeff.begin(),
                    [tmp](auto v, auto b) { return v * tmp[b]; });
   }
 

--- a/src/SPERR.cpp
+++ b/src/SPERR.cpp
@@ -105,8 +105,8 @@ auto sperr::SPERR::m_ready_to_encode() const -> bool
     return false;
 
   // Make sure each outlier to process has an error greater or equal to the tolerance.
-  if (!std::all_of(m_LOS.begin(), m_LOS.end(),
-                   [tol = m_tolerance](auto& out) { return std::abs(out.error) >= tol; }))
+  if (!std::all_of(m_LOS.cbegin(), m_LOS.cend(),
+                   [tol = m_tolerance](auto out) { return std::abs(out.error) >= tol; }))
     return false;
 
   // Make sure there are no duplicate locations in the outlier list,
@@ -114,8 +114,8 @@ auto sperr::SPERR::m_ready_to_encode() const -> bool
   // Note that the list of outliers is already sorted at the beginning of encoding.
   if (m_LOS.back().location >= m_total_len)
     return false;
-  auto adj = std::adjacent_find(m_LOS.begin(), m_LOS.end(),
-                                [](auto& a, auto& b) { return a.location == b.location; });
+  auto adj = std::adjacent_find(m_LOS.cbegin(), m_LOS.cend(),
+                                [](auto a, auto b) { return a.location == b.location; });
   return (adj == m_LOS.end());
 }
 
@@ -135,7 +135,7 @@ auto sperr::SPERR::encode() -> RTNType
   // Actually, if the list of outliers is produced by this package (SPECK3D_Compressor),
   // it's already in the desired order so this step has no cost!
   // Outliers added individually will potentially trigger actual sorting operations though.
-  std::sort(m_LOS.begin(), m_LOS.end(), [](auto& a, auto& b) { return a.location < b.location; });
+  std::sort(m_LOS.begin(), m_LOS.end(), [](auto a, auto b) { return a.location < b.location; });
   if (!m_ready_to_encode())
     return RTNType::InvalidParam;
   m_bit_buffer.clear();
@@ -330,7 +330,7 @@ void sperr::SPERR::m_refinement_pass_encoding()
   }
 
   // Now attach content from `m_LSP_new` to the end of `m_LSP_old`.
-  m_LSP_old.insert(m_LSP_old.end(), m_LSP_new.begin(), m_LSP_new.end());
+  m_LSP_old.insert(m_LSP_old.cend(), m_LSP_new.cbegin(), m_LSP_new.cend());
   m_LSP_new.clear();
 }
 

--- a/src/SPERR2D_Compressor.cpp
+++ b/src/SPERR2D_Compressor.cpp
@@ -118,7 +118,7 @@ auto SPERR2D_Compressor::compress() -> RTNType
   if (mode == sperr::CompMode::FixedPWE) {
     // Make a copy of the original data for outlier correction use.
     m_val_buf2.resize(total_vals);
-    std::copy(m_val_buf.begin(), m_val_buf.end(), m_val_buf2.begin());
+    std::copy(m_val_buf.cbegin(), m_val_buf.cend(), m_val_buf2.begin());
     auto [min, max] = std::minmax_element(m_val_buf.cbegin(), m_val_buf.cend());
     range_before = *max - *min;
   }
@@ -258,13 +258,13 @@ auto SPERR2D_Compressor::m_assemble_encoded_bitstream() -> RTNType
   // Task 2: assemble pieces of info together.
   m_encoded_stream.resize(total_size);
   auto itr = m_encoded_stream.begin();
-  std::copy(std::begin(meta), std::end(meta), itr);
+  std::copy(std::cbegin(meta), std::cend(meta), itr);
   itr += m_meta_size;
-  std::copy(m_condi_stream.begin(), m_condi_stream.end(), itr);
+  std::copy(m_condi_stream.cbegin(), m_condi_stream.cend(), itr);
   itr += m_condi_stream.size();
-  std::copy(m_speck_stream.begin(), m_speck_stream.end(), itr);
+  std::copy(m_speck_stream.cbegin(), m_speck_stream.cend(), itr);
   itr += m_speck_stream.size();
-  std::copy(m_sperr_stream.begin(), m_sperr_stream.end(), itr);
+  std::copy(m_sperr_stream.cbegin(), m_sperr_stream.cend(), itr);
   itr += m_sperr_stream.size();
   assert(itr == m_encoded_stream.end());
 
@@ -273,7 +273,7 @@ auto SPERR2D_Compressor::m_assemble_encoded_bitstream() -> RTNType
   const auto uncomp_size = total_size - m_meta_size;
   const auto comp_buf_len = ZSTD_compressBound(uncomp_size);
   auto comp_buf = sperr::vec8_type(m_meta_size + comp_buf_len);
-  std::copy(std::begin(meta), std::end(meta), comp_buf.begin());
+  std::copy(std::cbegin(meta), std::cend(meta), comp_buf.begin());
 
   auto comp_size =
       ZSTD_compress(comp_buf.data() + m_meta_size, comp_buf_len,

--- a/src/SPERR2D_Decompressor.cpp
+++ b/src/SPERR2D_Decompressor.cpp
@@ -121,7 +121,7 @@ template <typename T>
 auto SPERR2D_Decompressor::get_data() const -> std::vector<T>
 {
   auto out_buf = std::vector<T>(m_val_buf.size());
-  std::copy(m_val_buf.begin(), m_val_buf.end(), out_buf.begin());
+  std::copy(m_val_buf.cbegin(), m_val_buf.cend(), out_buf.begin());
 
   return out_buf;
 }

--- a/src/SPERR3D_Compressor.cpp
+++ b/src/SPERR3D_Compressor.cpp
@@ -177,7 +177,7 @@ auto sperr::SPERR3D_Compressor::m_assemble_encoded_bitstream() -> RTNType
   // stream.
   if (m_encoded_stream.empty())
     m_encoded_stream.resize(m_condi_stream.size());
-  std::copy(m_condi_stream.begin(), m_condi_stream.end(), m_encoded_stream.begin());
+  std::copy(m_condi_stream.cbegin(), m_condi_stream.cend(), m_encoded_stream.begin());
 
   // If there's outlier correction stream, copy it over too.
   if (!m_sperr_stream.empty()) {

--- a/src/SPERR3D_Decompressor.cpp
+++ b/src/SPERR3D_Decompressor.cpp
@@ -118,7 +118,7 @@ auto sperr::SPERR3D_Decompressor::decompress() -> RTNType
   // Step 3: Inverse Conditioning
   const auto& cdf_out = m_cdf.view_data();
   m_val_buf.resize(cdf_out.size());
-  std::copy(cdf_out.begin(), cdf_out.end(), m_val_buf.begin());
+  std::copy(cdf_out.cbegin(), cdf_out.cend(), m_val_buf.begin());
   m_conditioner.inverse_condition(m_val_buf, m_dims, m_condi_stream);
 
   // Step 4: If there's SPERR data, then do the correction.
@@ -142,7 +142,7 @@ template <typename T>
 auto sperr::SPERR3D_Decompressor::get_data() const -> std::vector<T>
 {
   auto out_buf = std::vector<T>(m_val_buf.size());
-  std::copy(m_val_buf.begin(), m_val_buf.end(), out_buf.begin());
+  std::copy(m_val_buf.cbegin(), m_val_buf.cend(), out_buf.begin());
 
   return out_buf;
 }

--- a/src/SPERR3D_OMP_C.cpp
+++ b/src/SPERR3D_OMP_C.cpp
@@ -28,7 +28,7 @@ auto SPERR3D_OMP_C::get_outlier_stats() const -> std::pair<size_t, size_t>
   auto op = [](const pair& a, const pair& b) -> pair {
     return {a.first + b.first, a.second + b.second};
   };
-  return std::accumulate(m_outlier_stats.begin(), m_outlier_stats.end(), sum, op);
+  return std::accumulate(m_outlier_stats.cbegin(), m_outlier_stats.cend(), sum, op);
 }
 
 auto SPERR3D_OMP_C::set_target_bpp(double bpp) -> RTNType
@@ -38,8 +38,8 @@ auto SPERR3D_OMP_C::set_target_bpp(double bpp) -> RTNType
 
   // If the volume and chunk dimension hasn't been set, return error.
   auto eq0 = [](auto v) { return v == 0; };
-  if (std::any_of(m_dims.begin(), m_dims.end(), eq0) ||
-      std::any_of(m_chunk_dims.begin(), m_chunk_dims.end(), eq0))
+  if (std::any_of(m_dims.cbegin(), m_dims.cend(), eq0) ||
+      std::any_of(m_chunk_dims.cbegin(), m_chunk_dims.cend(), eq0))
     return RTNType::SetBPPBeforeDims;
 
   const auto total_vals = static_cast<double>(m_dims[0] * m_dims[1] * m_dims[2]);
@@ -113,7 +113,7 @@ auto SPERR3D_OMP_C::compress() -> RTNType
   assert(num_chunks != 0);
   if (m_chunk_buffers.size() != num_chunks)
     return RTNType::Error;
-  if (std::any_of(m_chunk_buffers.begin(), m_chunk_buffers.end(),
+  if (std::any_of(m_chunk_buffers.cbegin(), m_chunk_buffers.cend(),
                   [](auto& v) { return v.empty(); }))
     return RTNType::Error;
 
@@ -169,11 +169,11 @@ auto SPERR3D_OMP_C::compress() -> RTNType
   }
 
   auto fail =
-      std::find_if(chunk_rtn.begin(), chunk_rtn.end(), [](auto r) { return r != RTNType::Good; });
+      std::find_if(chunk_rtn.cbegin(), chunk_rtn.cend(), [](auto r) { return r != RTNType::Good; });
   if (fail != chunk_rtn.end())
     return (*fail);
 
-  if (std::any_of(m_encoded_streams.begin(), m_encoded_streams.end(),
+  if (std::any_of(m_encoded_streams.cbegin(), m_encoded_streams.cend(),
                   [](auto& s) { return s.empty(); }))
     return RTNType::EmptyStream;
 
@@ -188,11 +188,11 @@ auto SPERR3D_OMP_C::get_encoded_bitstream() const -> std::vector<uint8_t>
     return buf;
 
   auto total_size =
-      std::accumulate(m_encoded_streams.begin(), m_encoded_streams.end(), header.size(),
+      std::accumulate(m_encoded_streams.cbegin(), m_encoded_streams.cend(), header.size(),
                       [](size_t a, const auto& b) { return a + b.size(); });
   buf.resize(total_size, 0);
 
-  std::copy(header.begin(), header.end(), buf.begin());
+  std::copy(header.cbegin(), header.cend(), buf.begin());
   auto itr = buf.begin() + header.size();
   for (const auto& s : m_encoded_streams) {
     std::copy(s.begin(), s.end(), itr);

--- a/src/SPERR3D_OMP_D.cpp
+++ b/src/SPERR3D_OMP_D.cpp
@@ -99,7 +99,7 @@ auto SPERR3D_OMP_D::use_bitstream(const void* p, size_t total_len) -> RTNType
   else
     header_size = m_header_magic_1chunk + num_chunks * 4;
 
-  const auto suppose_size = std::accumulate(chunk_sizes.begin(), chunk_sizes.end(), header_size);
+  const auto suppose_size = std::accumulate(chunk_sizes.cbegin(), chunk_sizes.cend(), header_size);
   if (suppose_size != total_len)
     return RTNType::BitstreamWrongLen;
 
@@ -118,8 +118,8 @@ auto SPERR3D_OMP_D::use_bitstream(const void* p, size_t total_len) -> RTNType
 auto SPERR3D_OMP_D::decompress(const void* p) -> RTNType
 {
   auto eq0 = [](auto v) { return v == 0; };
-  if (std::any_of(m_dims.begin(), m_dims.end(), eq0) ||
-      std::any_of(m_chunk_dims.begin(), m_chunk_dims.end(), eq0))
+  if (std::any_of(m_dims.cbegin(), m_dims.cend(), eq0) ||
+      std::any_of(m_chunk_dims.cbegin(), m_chunk_dims.cend(), eq0))
     return RTNType::Error;
   if (p == nullptr || m_bitstream_ptr == nullptr)
     return RTNType::Error;
@@ -164,7 +164,7 @@ auto SPERR3D_OMP_D::decompress(const void* p) -> RTNType
   }
 
   auto fail =
-      std::find_if(chunk_rtn.begin(), chunk_rtn.end(), [](auto r) { return r != RTNType::Good; });
+      std::find_if(chunk_rtn.cbegin(), chunk_rtn.cend(), [](auto r) { return r != RTNType::Good; });
   if (fail != chunk_rtn.end())
     return *fail;
   else
@@ -191,7 +191,7 @@ template <typename T>
 auto SPERR3D_OMP_D::get_data() const -> std::vector<T>
 {
   auto rtn_buf = std::vector<T>(m_vol_buf.size());
-  std::copy(m_vol_buf.begin(), m_vol_buf.end(), rtn_buf.begin());
+  std::copy(m_vol_buf.cbegin(), m_vol_buf.cend(), rtn_buf.begin());
   return rtn_buf;
 }
 template auto SPERR3D_OMP_D::get_data() const -> std::vector<float>;

--- a/src/sperr_helper.cpp
+++ b/src/sperr_helper.cpp
@@ -165,7 +165,7 @@ auto sperr::pack_8_booleans(std::array<bool, 8> src) -> uint8_t
   // It turns out that C++ doesn't specify bool to be one byte,
   // so to be safe we copy the content of src to array of uint8_t.
   auto bytes = std::array<uint8_t, 8>();
-  std::copy(src.begin(), src.end(), bytes.begin());
+  std::copy(src.cbegin(), src.cend(), bytes.begin());
   const uint64_t magic = 0x8040201008040201;
   uint64_t t = 0;
   std::memcpy(&t, bytes.data(), 8);
@@ -183,7 +183,7 @@ auto sperr::unpack_8_booleans(uint8_t src) -> std::array<bool, 8>
   auto bytes = std::array<uint8_t, 8>();
   std::memcpy(bytes.data(), &t, 8);
   auto b8 = std::array<bool, 8>();
-  std::copy(bytes.begin(), bytes.end(), b8.begin());
+  std::copy(bytes.cbegin(), bytes.cend(), b8.begin());
   return b8;
 }
 
@@ -323,7 +323,7 @@ auto sperr::calc_stats(const T* arr1, const T* arr2, size_t arr_len, size_t omp_
   //
   // Now calculate linfty
   //
-  linfty = *(std::max_element(linfty_vec.begin(), linfty_vec.end()));
+  linfty = *(std::max_element(linfty_vec.cbegin(), linfty_vec.cend()));
 
   //
   // Now calculate rmse and psnr
@@ -359,8 +359,7 @@ auto sperr::kahan_summation(const T* arr, size_t len) -> T
 template auto sperr::kahan_summation(const float*, size_t) -> float;
 template auto sperr::kahan_summation(const double*, size_t) -> double;
 
-auto sperr::chunk_volume(const std::array<size_t, 3>& vol_dim,
-                         const std::array<size_t, 3>& chunk_dim)
+auto sperr::chunk_volume(dims_type vol_dim, dims_type chunk_dim)
     -> std::vector<std::array<size_t, 6>>
 {
   // Step 1: figure out how many segments are there along each axis.


### PR DESCRIPTION
This is a minor improvement with the addition of many `const` keyword added to iterators and a few function interfaces. 
The motivation of this work is that occasionally `const` allows more aggressive compiler optimizations. 