### PR TITLE
More vec type

### DIFF
--- a/include/SPERR.h
+++ b/include/SPERR.h
@@ -50,7 +50,7 @@ class SPERR {
   // Output
   auto release_outliers() -> std::vector<Outlier>&&;  // Release ownership of decoded outliers
   auto view_outliers() -> const std::vector<Outlier>&;
-  auto get_encoded_bitstream() -> std::vector<uint8_t>;
+  auto get_encoded_bitstream() -> vec8_type;
   auto parse_encoded_bitstream(const void*, size_t) -> RTNType;
 
   // Given a SPERR stream, tell how long the sperr stream is.

--- a/include/SPERR2D_Compressor.h
+++ b/include/SPERR2D_Compressor.h
@@ -34,8 +34,8 @@ class SPERR2D_Compressor {
 
   auto compress() -> RTNType;
 
-  auto view_encoded_bitstream() const -> const std::vector<uint8_t>&;
-  auto release_encoded_bitstream() -> std::vector<uint8_t>&&;
+  auto view_encoded_bitstream() const -> const sperr::vec8_type&;
+  auto release_encoded_bitstream() -> sperr::vec8_type&&;
 
  private:
   sperr::dims_type m_dims = {0, 0, 0};

--- a/include/SPERR2D_Decompressor.h
+++ b/include/SPERR2D_Decompressor.h
@@ -23,7 +23,7 @@ class SPERR2D_Decompressor {
 
   // Get the decompressed data in a float or double buffer.
   template <typename T>
-  auto get_data() const -> std::vector<T>;
+  auto get_data() const -> sperr::vec_type<T>;
   auto release_data() -> sperr::vecd_type&&;
   auto view_data() const -> const sperr::vecd_type&;
   auto get_dims() const -> sperr::dims_type;

--- a/include/SPERR3D_Compressor.h
+++ b/include/SPERR3D_Compressor.h
@@ -31,8 +31,8 @@ class SPERR3D_Compressor {
 
   auto compress() -> RTNType;
 
-  auto view_encoded_bitstream() const -> const std::vector<uint8_t>&;
-  auto release_encoded_bitstream() -> std::vector<uint8_t>&&;
+  auto view_encoded_bitstream() const -> const vec8_type&;
+  auto release_encoded_bitstream() -> vec8_type&&;
 
  private:
   dims_type m_dims = {0, 0, 0};

--- a/include/SPERR3D_Decompressor.h
+++ b/include/SPERR3D_Decompressor.h
@@ -29,7 +29,7 @@ class SPERR3D_Decompressor {
 
   // Get the decompressed volume in a float or double buffer.
   template <typename T>
-  auto get_data() const -> std::vector<T>;
+  auto get_data() const -> sperr::vec_type<T>;
   auto view_data() const -> const sperr::vecd_type&;
   auto release_data() -> sperr::vecd_type&&;
 

--- a/include/SPERR3D_OMP_C.h
+++ b/include/SPERR3D_OMP_C.h
@@ -32,7 +32,7 @@ class SPERR3D_OMP_C {
   auto compress() -> RTNType;
 
   // Provide a copy of the encoded bitstream to the caller.
-  auto get_encoded_bitstream() const -> std::vector<uint8_t>;
+  auto get_encoded_bitstream() const -> sperr::vec8_type;
 
  private:
   sperr::dims_type m_dims = {0, 0, 0};        // Dimension of the entire volume

--- a/include/sperr_helper.h
+++ b/include/sperr_helper.h
@@ -20,6 +20,8 @@
 #include "SperrConfig.h"
 #endif
 
+#include "Kokkos_Vector.hpp"
+
 namespace sperr {
 
 using std::size_t;  // Seems most appropriate
@@ -32,7 +34,7 @@ constexpr auto max_d = std::numeric_limits<double>::max();
 // A few shortcuts
 //
 template <typename T>
-using vec_type = std::vector<T>;
+using vec_type = Kokkos::vector<T>;
 using vecf_type = vec_type<float>;
 using vecd_type = vec_type<double>;
 using vec8_type = vec_type<uint8_t>;

--- a/include/sperr_helper.h
+++ b/include/sperr_helper.h
@@ -20,8 +20,6 @@
 #include "SperrConfig.h"
 #endif
 
-#include "Kokkos_Vector.hpp"
-
 namespace sperr {
 
 using std::size_t;  // Seems most appropriate
@@ -34,7 +32,7 @@ constexpr auto max_d = std::numeric_limits<double>::max();
 // A few shortcuts
 //
 template <typename T>
-using vec_type = Kokkos::vector<T>;
+using vec_type = std::vector<T>;
 using vecf_type = vec_type<float>;
 using vecd_type = vec_type<double>;
 using vec8_type = vec_type<uint8_t>;

--- a/src/SPERR.cpp
+++ b/src/SPERR.cpp
@@ -376,7 +376,7 @@ void sperr::SPERR::m_refinement_pass_decoding()
   m_LOS_size = m_LOS.size();
 }
 
-auto sperr::SPERR::get_encoded_bitstream() -> std::vector<uint8_t>
+auto sperr::SPERR::get_encoded_bitstream() -> vec8_type
 {
   // Header definition:
   // total_len  max_threshold   num_of_bits
@@ -388,7 +388,7 @@ auto sperr::SPERR::get_encoded_bitstream() -> std::vector<uint8_t>
     m_bit_buffer.push_back(false);
 
   const size_t buf_len = m_header_size + m_bit_buffer.size() / 8;
-  auto buf = std::vector<uint8_t>(buf_len);
+  auto buf = vec8_type(buf_len);
 
   // Fill header
   size_t pos = 0;

--- a/src/SPERR2D_Compressor.cpp
+++ b/src/SPERR2D_Compressor.cpp
@@ -83,12 +83,12 @@ void SPERR2D_Compressor::set_target_pwe(double pwe)
   m_target_pwe = std::max(pwe, 0.0);
 }
 
-auto SPERR2D_Compressor::view_encoded_bitstream() const -> const std::vector<uint8_t>&
+auto SPERR2D_Compressor::view_encoded_bitstream() const -> const sperr::vec8_type&
 {
   return m_encoded_stream;
 }
 
-auto SPERR2D_Compressor::release_encoded_bitstream() -> std::vector<uint8_t>&&
+auto SPERR2D_Compressor::release_encoded_bitstream() -> sperr::vec8_type&&
 {
   return std::move(m_encoded_stream);
 }

--- a/src/SPERR2D_Decompressor.cpp
+++ b/src/SPERR2D_Decompressor.cpp
@@ -118,9 +118,9 @@ auto SPERR2D_Decompressor::use_bitstream(const void* p, size_t len) -> RTNType
 }
 
 template <typename T>
-auto SPERR2D_Decompressor::get_data() const -> std::vector<T>
+auto SPERR2D_Decompressor::get_data() const -> sperr::vec_type<T>
 {
-  auto out_buf = std::vector<T>(m_val_buf.size());
+  auto out_buf = sperr::vec_type<T>(m_val_buf.size());
   std::copy(m_val_buf.cbegin(), m_val_buf.cend(), out_buf.begin());
 
   return out_buf;

--- a/src/SPERR3D_Compressor.cpp
+++ b/src/SPERR3D_Compressor.cpp
@@ -33,12 +33,12 @@ auto sperr::SPERR3D_Compressor::take_data(sperr::vecd_type&& buf, sperr::dims_ty
   return RTNType::Good;
 }
 
-auto sperr::SPERR3D_Compressor::view_encoded_bitstream() const -> const std::vector<uint8_t>&
+auto sperr::SPERR3D_Compressor::view_encoded_bitstream() const -> const vec8_type&
 {
   return m_encoded_stream;
 }
 
-auto sperr::SPERR3D_Compressor::release_encoded_bitstream() -> std::vector<uint8_t>&&
+auto sperr::SPERR3D_Compressor::release_encoded_bitstream() -> vec8_type&&
 {
   return std::move(m_encoded_stream);
 }

--- a/src/SPERR3D_Decompressor.cpp
+++ b/src/SPERR3D_Decompressor.cpp
@@ -139,9 +139,9 @@ auto sperr::SPERR3D_Decompressor::decompress() -> RTNType
 }
 
 template <typename T>
-auto sperr::SPERR3D_Decompressor::get_data() const -> std::vector<T>
+auto sperr::SPERR3D_Decompressor::get_data() const -> vec_type<T>
 {
-  auto out_buf = std::vector<T>(m_val_buf.size());
+  auto out_buf = vec_type<T>(m_val_buf.size());
   std::copy(m_val_buf.cbegin(), m_val_buf.cend(), out_buf.begin());
 
   return out_buf;

--- a/src/SPERR3D_OMP_C.cpp
+++ b/src/SPERR3D_OMP_C.cpp
@@ -214,14 +214,14 @@ auto SPERR3D_OMP_C::m_generate_header() const -> sperr::vec8_type
   const auto num_chunks = chunks.size();
   assert(num_chunks != 0);
   if (num_chunks != m_encoded_streams.size())
-    return std::vector<uint8_t>();
+    return sperr::vec8_type();
   auto header_size = size_t{0};
   if (num_chunks > 1)
     header_size = m_header_magic_nchunks + num_chunks * 4;
   else
     header_size = m_header_magic_1chunk + num_chunks * 4;
 
-  auto header = std::vector<uint8_t>(header_size);
+  auto header = sperr::vec8_type(header_size);
 
   // Version number
   header[0] = static_cast<uint8_t>(SPERR_VERSION_MAJOR);

--- a/src/SPERR3D_OMP_C.cpp
+++ b/src/SPERR3D_OMP_C.cpp
@@ -163,7 +163,13 @@ auto SPERR3D_OMP_C::compress() -> RTNType
       chunk_rtn[i] = compressor.compress();
     }
 
-    m_encoded_streams[i] = compressor.view_encoded_bitstream();
+    //
+    // Cumbersome because Kokkos vector behaves incorrectly with the following direct assignment.
+    // m_encoded_streams[i] = compressor.view_encoded_bitstream();
+    //
+    const auto& handle = compressor.view_encoded_bitstream();
+    m_encoded_streams[i].resize(handle.size());
+    std::copy(handle.cbegin(), handle.cend(), m_encoded_streams[i].begin());
 
     m_outlier_stats[i] = compressor.get_outlier_stats();
   }
@@ -180,9 +186,9 @@ auto SPERR3D_OMP_C::compress() -> RTNType
   return RTNType::Good;
 }
 
-auto SPERR3D_OMP_C::get_encoded_bitstream() const -> std::vector<uint8_t>
+auto SPERR3D_OMP_C::get_encoded_bitstream() const -> sperr::vec8_type
 {
-  auto buf = std::vector<uint8_t>();
+  auto buf = sperr::vec8_type();
   auto header = m_generate_header();
   if (header.empty())
     return buf;
@@ -195,7 +201,7 @@ auto SPERR3D_OMP_C::get_encoded_bitstream() const -> std::vector<uint8_t>
   std::copy(header.cbegin(), header.cend(), buf.begin());
   auto itr = buf.begin() + header.size();
   for (const auto& s : m_encoded_streams) {
-    std::copy(s.begin(), s.end(), itr);
+    std::copy(s.cbegin(), s.cend(), itr);
     itr += s.size();
   }
 

--- a/src/SPERR3D_OMP_C.cpp
+++ b/src/SPERR3D_OMP_C.cpp
@@ -210,6 +210,8 @@ auto SPERR3D_OMP_C::get_encoded_bitstream() const -> sperr::vec8_type
 
 auto SPERR3D_OMP_C::m_generate_header() const -> sperr::vec8_type
 {
+  auto header = sperr::vec8_type();
+
   // The header would contain the following information
   //  -- a version number                     (1 byte)
   //  -- 8 booleans                           (1 byte)
@@ -220,14 +222,14 @@ auto SPERR3D_OMP_C::m_generate_header() const -> sperr::vec8_type
   const auto num_chunks = chunks.size();
   assert(num_chunks != 0);
   if (num_chunks != m_encoded_streams.size())
-    return sperr::vec8_type();
+    return header;
   auto header_size = size_t{0};
   if (num_chunks > 1)
     header_size = m_header_magic_nchunks + num_chunks * 4;
   else
     header_size = m_header_magic_1chunk + num_chunks * 4;
 
-  auto header = sperr::vec8_type(header_size);
+  header.resize(header_size);
 
   // Version number
   header[0] = static_cast<uint8_t>(SPERR_VERSION_MAJOR);

--- a/src/SPERR3D_OMP_D.cpp
+++ b/src/SPERR3D_OMP_D.cpp
@@ -177,7 +177,7 @@ auto SPERR3D_OMP_D::release_data() -> sperr::vecd_type&&
   return std::move(m_vol_buf);
 }
 
-auto SPERR3D_OMP_D::view_data() const -> const std::vector<double>&
+auto SPERR3D_OMP_D::view_data() const -> const sperr::vecd_type&
 {
   return m_vol_buf;
 }

--- a/test_scripts/sperr_helper_unit_test.cpp
+++ b/test_scripts/sperr_helper_unit_test.cpp
@@ -57,7 +57,7 @@ TEST(sperr_helper, bit_packing)
                           true,  true,  true,  false, true,  true,  true,  false,  // 10th byte
                           false, false, true,  true,  true,  false, false, true};  // 11th byte
 
-  auto bytes = std::vector<uint8_t>(num_of_bytes + byte_offset);
+  auto bytes = sperr::vec8_type(num_of_bytes + byte_offset);
 
   // Pack booleans
   auto rtn1 = sperr::pack_booleans(bytes, input, byte_offset);
@@ -119,7 +119,7 @@ TEST(sperr_helper, bit_packing_1032_bools)
   std::mt19937 gen(rd());  // Standard mersenne_twister_engine seeded with rd()
   std::uniform_int_distribution<> distrib(0, 2);
   auto input = std::vector<bool>(num_of_bits);
-  auto bytes = std::vector<uint8_t>(num_of_bytes + byte_offset);
+  auto bytes = sperr::vec8_type(num_of_bytes + byte_offset);
   for (size_t i = 0; i < num_of_bits; i++)
     input[i] = distrib(gen);
 


### PR DESCRIPTION
Use `vec_type` in more places. Also identified an error when assigning to a `kokkos::vector`, and also found a workaround. 