### PR TITLE
Custom bitmask for m_LSP_mask

### DIFF
--- a/include/Bitmask.h
+++ b/include/Bitmask.h
@@ -1,0 +1,39 @@
+#ifndef BITMASK_H
+#define BITMASK_H
+
+#include <cstdint>
+#include <vector>
+
+namespace sperr {
+
+class Bitmask {
+ public:
+  // Constructor
+  Bitmask(size_t nbits = 0); // How many bits does it hold initially?
+
+  // Functions for both read and write
+  //
+  auto size() const -> size_t;  // Report the current size (in num of bits).
+  void resize(size_t nbits);    // Resize to hold n bits.
+  void reset();                 // Set the current bitmask to be all 0s.
+
+  // Functions for read
+  //
+  // Return the long that contains the requested idx.
+  auto read_long(size_t idx) const -> uint64_t;
+  auto read_bit(size_t idx) const -> bool;
+
+  // Functions for write
+  //
+  // Over-writes the long that contains `idx` with `value`.
+  void write_long(size_t idx, uint64_t value);
+  void write_bit(size_t idx, bool bit);
+
+ private:
+  std::vector<uint64_t> m_buf;
+  size_t m_num_bits = 0;
+};
+
+};  // namespace sperr
+
+#endif

--- a/include/Bitmask.h
+++ b/include/Bitmask.h
@@ -1,6 +1,7 @@
 #ifndef BITMASK_H
 #define BITMASK_H
 
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 
@@ -19,19 +20,19 @@ class Bitmask {
 
   // Functions for read
   //
-  // Return the long that contains the requested idx.
+  // Return the long (uint64_t) that contains the bit at the requested idx.
   auto read_long(size_t idx) const -> uint64_t;
   auto read_bit(size_t idx) const -> bool;
 
   // Functions for write
   //
-  // Over-writes the long that contains `idx` with `value`.
+  // Over-writes the long (uint64_t) that contains the bit at `idx` with `value`.
   void write_long(size_t idx, uint64_t value);
   void write_bit(size_t idx, bool bit);
 
  private:
   std::vector<uint64_t> m_buf;
-  size_t m_num_bits = 0;
+  size_t m_num_bits = 0; // The actual number of bits in use; not necessarily 64 * m_buf.size()
 };
 
 };  // namespace sperr

--- a/include/Bitmask.h
+++ b/include/Bitmask.h
@@ -10,7 +10,7 @@ namespace sperr {
 class Bitmask {
  public:
   // Constructor
-  Bitmask(size_t nbits = 0); // How many bits does it hold initially?
+  Bitmask(size_t nbits = 0);  // How many bits does it hold initially?
 
   // Functions for both read and write
   //
@@ -32,7 +32,7 @@ class Bitmask {
 
  private:
   std::vector<uint64_t> m_buf;
-  size_t m_num_bits = 0; // The actual number of bits in use; not necessarily 64 * m_buf.size()
+  size_t m_num_bits = 0;  // The actual number of bits in use; not necessarily 64 * m_buf.size()
 };
 
 };  // namespace sperr

--- a/include/Bitstream.h
+++ b/include/Bitstream.h
@@ -3,7 +3,6 @@
 
 #include "zfp_bitstream.h"
 
-#include <cassert>
 #include <cstdint>
 #include <vector>
 

--- a/include/SPECK1D_INT_DEC.h
+++ b/include/SPECK1D_INT_DEC.h
@@ -15,14 +15,10 @@ class SPECK1D_INT_DEC : public SPECK1D_INT {
 
  private:
   virtual void m_sorting_pass() override;
-  virtual void m_refinement_pass() override;
 
   void m_process_S(size_t idx1, size_t idx2, size_t& counter, bool read);
   void m_process_P(size_t idx, size_t& counter, bool);
   void m_code_S(size_t idx1, size_t idx2);
-
-  // Data members
-  std::vector<bool>::const_iterator  m_bit_itr;
 };
 
 };  // namespace sperr

--- a/include/SPECK1D_INT_ENC.h
+++ b/include/SPECK1D_INT_ENC.h
@@ -15,7 +15,6 @@ class SPECK1D_INT_ENC : public SPECK1D_INT {
 
  private:
   virtual void m_sorting_pass() override;
-  virtual void m_refinement_pass() override;
 
   void m_process_S(size_t idx1, size_t idx2, SigType, size_t& counter, bool);
   void m_process_P(size_t idx, SigType, size_t& counter, bool);

--- a/include/SPECK3D_INT.h
+++ b/include/SPECK3D_INT.h
@@ -16,7 +16,7 @@ class Set3D {
   uint32_t length_x = 0;
   uint32_t length_y = 0;
   uint32_t length_z = 0;
-  // which partition level is this set at (starting from zero, in all 3 directions). 
+  // which partition level is this set at (starting from zero, in all 3 directions).
   // This data member is the sum of all 3 partition levels.
   uint16_t part_level = 0;
   SetType type = SetType::TypeS;  // Only used to indicate garbage status
@@ -38,7 +38,6 @@ class SPECK3D_INT : public SPECK_INT {
   virtual ~SPECK3D_INT() = default;
 
  protected:
-
   virtual void m_clean_LIS() override;
   virtual void m_initialize_lists() override;
 

--- a/include/SPECK3D_INT_DEC.h
+++ b/include/SPECK3D_INT_DEC.h
@@ -15,14 +15,10 @@ class SPECK3D_INT_DEC : public SPECK3D_INT {
 
  private:
   virtual void m_sorting_pass() override;
-  virtual void m_refinement_pass() override;
 
   void m_process_S(size_t idx1, size_t idx2, size_t& counter, bool);
   void m_process_P(size_t idx, size_t& counter, bool);
   void m_code_S(size_t idx1, size_t idx2);
-
-  // Data members
-  std::vector<bool>::const_iterator  m_bit_itr;
 };
 
 };  // namespace sperr

--- a/include/SPECK3D_INT_ENC.h
+++ b/include/SPECK3D_INT_ENC.h
@@ -15,7 +15,6 @@ class SPECK3D_INT_ENC : public SPECK3D_INT {
 
  private:
   virtual void m_sorting_pass() override;
-  virtual void m_refinement_pass() override;
 
   void m_process_S(size_t idx1, size_t idx2, SigType, size_t& counter, bool);
   void m_process_P(size_t idx, SigType, size_t& counter, bool);

--- a/include/SPECK3D_INT_ENC.h
+++ b/include/SPECK3D_INT_ENC.h
@@ -23,7 +23,6 @@ class SPECK3D_INT_ENC : public SPECK3D_INT {
   // Decide if a set is significant or not.
   // If it is significant, also identify the point that makes it significant.
   auto m_decide_significance(const Set3D&) const -> std::pair<SigType, std::array<uint32_t, 3>>;
-
 };
 
 };  // namespace sperr

--- a/include/SPECK_INT.h
+++ b/include/SPECK_INT.h
@@ -11,11 +11,10 @@ namespace sperr {
 
 class SPECK_INT {
  public:
-
   // Virtual destructor
   virtual ~SPECK_INT() = default;
 
-  void set_dims(dims_type);  
+  void set_dims(dims_type);
 
   // Retrieve the full length of a SPECK bitstream from its header
   auto get_speck_full_len(const void*) const -> uint64_t;
@@ -46,8 +45,8 @@ class SPECK_INT {
 
   // Misc. procedures
   virtual void m_assemble_bitstream();
-  //virtual auto m_ready_to_encode() const -> RTNType;
-  //virtual auto m_ready_to_decode() const -> RTNType;
+  // virtual auto m_ready_to_encode() const -> RTNType;
+  // virtual auto m_ready_to_decode() const -> RTNType;
 
   // Data members
   dims_type m_dims = {0, 0, 0};
@@ -61,7 +60,7 @@ class SPECK_INT {
   std::vector<bool>::const_iterator m_bit_itr;
 
   const size_t m_u64_garbage_val = std::numeric_limits<size_t>::max();
-  const size_t m_header_size = 9; // 9 bytes
+  const size_t m_header_size = 9;  // 9 bytes
 
 };  // class SPECK_INT
 

--- a/include/SPECK_INT.h
+++ b/include/SPECK_INT.h
@@ -5,7 +5,7 @@
 
 #include "sperr_helper.h"
 
-#include "Bitstream.h"
+#include "Bitmask.h"
 
 namespace sperr {
 
@@ -53,7 +53,8 @@ class SPECK_INT {
   uint_t m_threshold = 0;
   vecui_t m_coeff_buf;
   vec8_type m_encoded_bitstream;
-  vecb_type m_bit_buffer, m_LSP_mask, m_sign_array;
+  vecb_type m_bit_buffer, m_sign_array;
+  Bitmask m_LSP_mask;
   std::vector<uint64_t> m_LIP, m_LSP_new;
   uint8_t m_num_bitplanes = 0;
 

--- a/include/SPECK_INT.h
+++ b/include/SPECK_INT.h
@@ -41,7 +41,8 @@ class SPECK_INT {
   virtual void m_clean_LIS() = 0;
   virtual void m_initialize_lists() = 0;
   virtual void m_sorting_pass() = 0;
-  virtual void m_refinement_pass() = 0;
+  virtual void m_refinement_pass_encode();
+  virtual void m_refinement_pass_decode();
 
   // Misc. procedures
   virtual void m_assemble_bitstream();
@@ -57,6 +58,7 @@ class SPECK_INT {
   Bitmask m_LSP_mask;
   std::vector<uint64_t> m_LIP, m_LSP_new;
   uint8_t m_num_bitplanes = 0;
+  std::vector<bool>::const_iterator m_bit_itr;
 
   const size_t m_u64_garbage_val = std::numeric_limits<size_t>::max();
   const size_t m_header_size = 9; // 9 bytes

--- a/include/SPERR_Driver.h
+++ b/include/SPERR_Driver.h
@@ -11,9 +11,8 @@
 
 namespace sperr {
 
-class SPERR_Driver{
+class SPERR_Driver {
  public:
-
   //
   // Virtual Destructor
   //
@@ -24,14 +23,14 @@ class SPERR_Driver{
   //
   // Accept incoming data: copy from a raw memory block
   template <typename T>
-  void copy_data(const T* p,      // Input: pointer to the memory block
-                 size_t len);     // Input: number of values
+  void copy_data(const T* p,   // Input: pointer to the memory block
+                 size_t len);  // Input: number of values
 
   // Accept incoming data: take ownership of a memory block
   void take_data(std::vector<double>&&);
 
   // Use an encoded bitstream
-  virtual auto use_bitstream(const void* p, size_t len) -> RTNType; 
+  virtual auto use_bitstream(const void* p, size_t len) -> RTNType;
 
   //
   // Output
@@ -61,23 +60,23 @@ class SPERR_Driver{
   virtual auto decompress() -> RTNType;
 
  protected:
-  dims_type            m_dims = {0, 0, 0};
-  double               m_q = 1.0;     // 1.0 is a better initial value than 0.0
-  vecd_type            m_vals_d;
-  std::vector<int64_t> m_vals_ll;     // Signed integers produced by std::llrint()
-  vecui_t              m_vals_ui;     // Unsigned integers to be passed to the encoder
-  vecb_type            m_sign_array;  // Signs to be passed to the encoder
+  dims_type m_dims = {0, 0, 0};
+  double m_q = 1.0;  // 1.0 is a better initial value than 0.0
+  vecd_type m_vals_d;
+  std::vector<int64_t> m_vals_ll;  // Signed integers produced by std::llrint()
+  vecui_t m_vals_ui;               // Unsigned integers to be passed to the encoder
+  vecb_type m_sign_array;          // Signs to be passed to the encoder
   Conditioner::settings_type m_conditioning_settings = {true, false, false, false};
 
   Conditioner::meta_type m_condi_bitstream;
-  vec8_type              m_speck_bitstream;
+  vec8_type m_speck_bitstream;
 
   CDF97 m_cdf;
   Conditioner m_conditioner;
   std::unique_ptr<SPECK_INT> m_encoder = nullptr;
   std::unique_ptr<SPECK_INT> m_decoder = nullptr;
 
-  auto m_midtread_f2i() -> RTNType; 
+  auto m_midtread_f2i() -> RTNType;
   void m_midtread_i2f();
 
   // Both wavelet transforms operate on `m_vals_d`.
@@ -92,7 +91,6 @@ class SPERR_Driver{
   // Optional procedures for flexibility
   virtual auto m_proc_1() -> RTNType;
   virtual auto m_proc_2() -> RTNType;
-
 };
 
 };  // namespace sperr

--- a/include/sperr_helper.h
+++ b/include/sperr_helper.h
@@ -36,8 +36,8 @@ using vecb_type = std::vector<bool>;
 using vec8_type = std::vector<uint8_t>;
 using dims_type = std::array<size_t, 3>;
 
-using uint_t = uint64_t; // temporary use
-using vecui_t = std::vector<uint_t>; // temporary use
+using uint_t = uint64_t;              // temporary use
+using vecui_t = std::vector<uint_t>;  // temporary use
 
 //
 // Helper classes

--- a/include/zfp_bitstream.h
+++ b/include/zfp_bitstream.h
@@ -3,10 +3,8 @@
 
 #include <stddef.h>
 #include <stdint.h> /* Sam addition */
-/* 
- * #include "zfp/internal/zfp/types.h"
- * #include "zfp/internal/zfp/system.h"
- */
+
+/* clang-format off */
 
 typedef uint32_t uint;    /* Sam */
 typedef uint64_t uint64;  /* Sam */
@@ -119,5 +117,7 @@ int stream_set_stride(bitstream* stream, size_t block, ptrdiff_t delta);
 }
 #endif
 #endif /* !inline_ */
+
+/* clang-format off */
 
 #endif

--- a/src/Bitmask.cpp
+++ b/src/Bitmask.cpp
@@ -1,0 +1,63 @@
+#include "Bitmask.h"
+
+#include <algorithm>
+
+sperr::Bitmask::Bitmask(size_t nbits)
+{
+  if (nbits > 0) {
+    auto num_longs = nbits / 64;
+    if (nbits % 64 != 0)
+      num_longs++;
+    m_buf.assign(num_longs, 0);
+    m_num_bits = num_longs * 64;
+  }
+}
+
+auto sperr::Bitmask::size() const -> size_t
+{
+  return m_num_bits;
+}
+
+void sperr::Bitmask::resize(size_t nbits) 
+{
+  auto num_longs = nbits / 64;
+  if (nbits % 64 != 0)
+    num_longs++;
+  m_buf.resize(num_longs);
+  m_num_bits = num_longs * 64;
+}
+
+void sperr::Bitmask::reset()
+{
+  std::fill(m_buf.begin(), m_buf.end(), 0);
+}
+
+auto sperr::Bitmask::read_long(size_t idx) const -> uint64_t
+{
+  return m_buf[idx / 64];
+}
+
+auto sperr::Bitmask::read_bit(size_t idx) const -> bool
+{
+  auto word = m_buf[idx / 64];
+  word &= uint64_t(1ul) << (idx % 64);
+  return (word != 0);
+}
+
+void sperr::Bitmask::write_long(size_t idx, uint64_t value)
+{
+  m_buf[idx / 64] = value;
+}
+
+void sperr::Bitmask::write_bit(size_t idx, bool bit)
+{
+  const auto wstart = idx / 64;
+
+  auto word = m_buf[wstart];
+  const auto mask = uint64_t(1ul) << (idx % 64);
+  if (bit)
+    word |= mask;
+  else
+    word &= ~mask;
+  m_buf[wstart] = word;
+}

--- a/src/Bitmask.cpp
+++ b/src/Bitmask.cpp
@@ -18,7 +18,7 @@ auto sperr::Bitmask::size() const -> size_t
   return m_num_bits;
 }
 
-void sperr::Bitmask::resize(size_t nbits) 
+void sperr::Bitmask::resize(size_t nbits)
 {
   auto num_longs = nbits / 64;
   if (nbits % 64 != 0)

--- a/src/Bitmask.cpp
+++ b/src/Bitmask.cpp
@@ -9,7 +9,7 @@ sperr::Bitmask::Bitmask(size_t nbits)
     if (nbits % 64 != 0)
       num_longs++;
     m_buf.assign(num_longs, 0);
-    m_num_bits = num_longs * 64;
+    m_num_bits = nbits;
   }
 }
 
@@ -24,7 +24,7 @@ void sperr::Bitmask::resize(size_t nbits)
   if (nbits % 64 != 0)
     num_longs++;
   m_buf.resize(num_longs);
-  m_num_bits = num_longs * 64;
+  m_num_bits = nbits;
 }
 
 void sperr::Bitmask::reset()
@@ -40,7 +40,7 @@ auto sperr::Bitmask::read_long(size_t idx) const -> uint64_t
 auto sperr::Bitmask::read_bit(size_t idx) const -> bool
 {
   auto word = m_buf[idx / 64];
-  word &= uint64_t(1ul) << (idx % 64);
+  word &= uint64_t(1) << (idx % 64);
   return (word != 0);
 }
 
@@ -54,7 +54,7 @@ void sperr::Bitmask::write_bit(size_t idx, bool bit)
   const auto wstart = idx / 64;
 
   auto word = m_buf[wstart];
-  const auto mask = uint64_t(1ul) << (idx % 64);
+  const auto mask = uint64_t(1) << (idx % 64);
   if (bit)
     word |= mask;
   else

--- a/src/Bitstream.cpp
+++ b/src/Bitstream.cpp
@@ -1,6 +1,7 @@
 #include "Bitstream.h"
 
 #include <algorithm>  // std::max()
+#include <cassert>
 #include <cstring>
 
 // Constructor

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library( SPERR
              sperr_helper.cpp
              zfp_bitstream.c
              Bitstream.cpp
+             Bitmask.cpp
              Conditioner.cpp
              CDF97.cpp
              SPECK_INT.cpp
@@ -56,6 +57,7 @@ set( public_h_list
 "include/sperr_helper.h;\
 include/zfp_bitstream.h;\
 include/Bitstream.h;\
+include/Bitmask.h;\
 include/Conditioner.h;\
 include/CDF97.h;\
 include/SPECK_INT.h;\

--- a/src/SPECK1D_INT_DEC.cpp
+++ b/src/SPECK1D_INT_DEC.cpp
@@ -15,7 +15,9 @@ void sperr::SPECK1D_INT_DEC::decode()
   m_sign_array.assign(coeff_len, true);
 
   // Mark every coefficient as insignificant
-  m_LSP_mask.assign(m_coeff_buf.size(), false);
+  //m_LSP_mask.assign(m_coeff_buf.size(), false);
+  m_LSP_mask.resize(m_coeff_buf.size());
+  m_LSP_mask.reset();
   m_bit_itr = m_bit_buffer.cbegin();
 
   // Restore the biggest `m_threshold`
@@ -57,17 +59,29 @@ void sperr::SPECK1D_INT_DEC::m_refinement_pass()
   //
   const auto tmp = std::array<uint_t, 2>{uint_t{0}, m_threshold};
 
-  for (size_t i = 0; i < m_LSP_mask.size(); i++) {
-    if (m_LSP_mask[i]) {
-      m_coeff_buf[i] += tmp[*m_bit_itr];
-      ++m_bit_itr;
+  //for (size_t i = 0; i < m_LSP_mask.size(); i++) {
+  //  if (m_LSP_mask[i]) {
+  //    m_coeff_buf[i] += tmp[*m_bit_itr];
+  //    ++m_bit_itr;
+  //  }
+  //}
+  for (size_t i = 0; i < m_LSP_mask.size(); i += 64) {
+    const auto value = m_LSP_mask.read_long(i);  
+    if (value != 0ul) {
+      for (size_t j = 0; j < 64ul; j++) {
+        if ((value >> j) & uint64_t(1ul)) {
+          m_coeff_buf[i + j] += tmp[*m_bit_itr];
+          ++m_bit_itr;
+        }
+      }
     }
   }
 
   // Second, mark newly found significant pixels in `m_LSP_mark`
   //
   for (auto idx : m_LSP_new)
-    m_LSP_mask[idx] = true;
+    m_LSP_mask.write_bit(idx, true);
+    //m_LSP_mask[idx] = true;
   m_LSP_new.clear();
 }
 

--- a/src/SPECK1D_INT_DEC.cpp
+++ b/src/SPECK1D_INT_DEC.cpp
@@ -15,7 +15,6 @@ void sperr::SPECK1D_INT_DEC::decode()
   m_sign_array.assign(coeff_len, true);
 
   // Mark every coefficient as insignificant
-  //m_LSP_mask.assign(m_coeff_buf.size(), false);
   m_LSP_mask.resize(m_coeff_buf.size());
   m_LSP_mask.reset();
   m_bit_itr = m_bit_buffer.cbegin();
@@ -33,7 +32,6 @@ void sperr::SPECK1D_INT_DEC::decode()
     m_clean_LIS();
   }
 }
-
 
 void sperr::SPECK1D_INT_DEC::m_sorting_pass()
 {
@@ -116,7 +114,7 @@ void sperr::SPECK1D_INT_DEC::m_code_S(size_t idx1, size_t idx2)
     read = false;
   const auto& set1 = subsets[1];
   assert(set1.length != 0);
-  if (set1.length == 1 ) {
+  if (set1.length == 1) {
     m_LIP.push_back(set1.start);
     m_process_P(m_LIP.size() - 1, sig_counter, read);
   }
@@ -126,6 +124,3 @@ void sperr::SPECK1D_INT_DEC::m_code_S(size_t idx1, size_t idx2)
     m_process_S(newidx1, m_LIS[newidx1].size() - 1, sig_counter, read);
   }
 }
-
-
-

--- a/src/SPECK1D_INT_DEC.cpp
+++ b/src/SPECK1D_INT_DEC.cpp
@@ -27,7 +27,7 @@ void sperr::SPECK1D_INT_DEC::decode()
 
   for (uint8_t bitplane = 0; bitplane < m_num_bitplanes; bitplane++) {
     m_sorting_pass();
-    m_refinement_pass();
+    m_refinement_pass_decode();
 
     m_threshold /= uint_t{2};
     m_clean_LIS();
@@ -51,38 +51,6 @@ void sperr::SPECK1D_INT_DEC::m_sorting_pass()
     for (size_t idx2 = 0; idx2 < m_LIS[idx1].size(); idx2++)
       m_process_S(idx1, idx2, dummy, true);
   }
-}
-
-void sperr::SPECK1D_INT_DEC::m_refinement_pass()
-{
-  // First, process significant pixels previously found.
-  //
-  const auto tmp = std::array<uint_t, 2>{uint_t{0}, m_threshold};
-
-  //for (size_t i = 0; i < m_LSP_mask.size(); i++) {
-  //  if (m_LSP_mask[i]) {
-  //    m_coeff_buf[i] += tmp[*m_bit_itr];
-  //    ++m_bit_itr;
-  //  }
-  //}
-  for (size_t i = 0; i < m_LSP_mask.size(); i += 64) {
-    const auto value = m_LSP_mask.read_long(i);  
-    if (value != 0ul) {
-      for (size_t j = 0; j < 64ul; j++) {
-        if ((value >> j) & uint64_t(1ul)) {
-          m_coeff_buf[i + j] += tmp[*m_bit_itr];
-          ++m_bit_itr;
-        }
-      }
-    }
-  }
-
-  // Second, mark newly found significant pixels in `m_LSP_mark`
-  //
-  for (auto idx : m_LSP_new)
-    m_LSP_mask.write_bit(idx, true);
-    //m_LSP_mask[idx] = true;
-  m_LSP_new.clear();
 }
 
 void sperr::SPECK1D_INT_DEC::m_process_S(size_t idx1, size_t idx2, size_t& counter, bool read)

--- a/src/SPECK1D_INT_ENC.cpp
+++ b/src/SPECK1D_INT_ENC.cpp
@@ -13,7 +13,6 @@ void sperr::SPECK1D_INT_ENC::encode()
   m_initialize_lists();
 
   // Mark every coefficient as insignificant
-  //m_LSP_mask.assign(m_coeff_buf.size(), false);
   m_LSP_mask.resize(m_coeff_buf.size());
   m_LSP_mask.reset();
 
@@ -74,7 +73,7 @@ void sperr::SPECK1D_INT_ENC::m_process_S(size_t idx1,
   //    subsets' significance is unknown.
   // 3) if sig is insignificant, then this set is not processed.
 
-  auto subset_sigs = std::array<SigType, 2>{SigType::Dunno, SigType::Dunno}; 
+  auto subset_sigs = std::array<SigType, 2>{SigType::Dunno, SigType::Dunno};
 
   if (sig == SigType::Dunno) {
     auto set_sig = m_decide_significance(set);
@@ -82,9 +81,9 @@ void sperr::SPECK1D_INT_ENC::m_process_S(size_t idx1,
     if (sig == SigType::Sig) {
       assert(set_sig.second >= 0);
       if (set_sig.second < set.length - set.length / 2)
-        subset_sigs = {SigType::Sig, SigType::Dunno}; 
+        subset_sigs = {SigType::Sig, SigType::Dunno};
       else
-        subset_sigs = {SigType::Insig, SigType::Sig}; 
+        subset_sigs = {SigType::Insig, SigType::Sig};
     }
   }
 

--- a/src/SPECK1D_INT_ENC.cpp
+++ b/src/SPECK1D_INT_ENC.cpp
@@ -28,7 +28,7 @@ void sperr::SPECK1D_INT_ENC::encode()
 
   for (uint8_t bitplane = 0; bitplane < m_num_bitplanes; bitplane++) {
     m_sorting_pass();
-    m_refinement_pass();
+    m_refinement_pass_encode();
 
     m_threshold /= uint_t{2};
     m_clean_LIS();
@@ -54,40 +54,6 @@ void sperr::SPECK1D_INT_ENC::m_sorting_pass()
     for (size_t idx2 = 0; idx2 < m_LIS[idx1].size(); idx2++)
       m_process_S(idx1, idx2, SigType::Dunno, dummy, true);
   }
-}
-
-void sperr::SPECK1D_INT_ENC::m_refinement_pass()
-{
-  // First, process significant pixels previously found.
-  //
-  const auto tmp1 = std::array<uint_t, 2>{0, m_threshold};
-
-  //for (size_t i = 0; i < m_LSP_mask.size(); i++) {
-  //  if (m_LSP_mask[i]) {
-  //    const bool o1 = m_coeff_buf[i] >= m_threshold;
-  //    m_bit_buffer.push_back(o1);
-  //    m_coeff_buf[i] -= tmp1[o1];
-  //  }
-  //}
-  for (size_t i = 0; i < m_LSP_mask.size(); i += 64) {
-    const auto value = m_LSP_mask.read_long(i);
-    if (value != 0ul) {
-      for (size_t j = 0; j < 64ul; j++) {
-        if ((value >> j) & uint64_t(1ul)) {
-          const bool o1 = m_coeff_buf[i + j] >= m_threshold;
-          m_bit_buffer.push_back(o1);
-          m_coeff_buf[i + j] -= tmp1[o1];
-        }
-      }
-    }
-  }
-
-  // Second, mark newly found significant pixels in `m_LSP_mask`.
-  //
-  for (auto idx : m_LSP_new)
-    m_LSP_mask.write_bit(idx, true);
-    //m_LSP_mask[idx] = true;
-  m_LSP_new.clear();
 }
 
 void sperr::SPECK1D_INT_ENC::m_process_S(size_t idx1,

--- a/src/SPECK3D_INT.cpp
+++ b/src/SPECK3D_INT.cpp
@@ -5,16 +5,16 @@
 #include <cstring>
 #include <numeric>
 
-auto sperr::Set3D::is_pixel() const -> bool 
-{ 
-  return (length_x == 1 && length_y == 1 && length_z == 1); 
+auto sperr::Set3D::is_pixel() const -> bool
+{
+  return (length_x == 1 && length_y == 1 && length_z == 1);
 }
 
-auto sperr::Set3D::is_empty() const -> bool 
-{ 
-  return (length_z == 0 || length_y == 0 || length_x == 0); 
+auto sperr::Set3D::is_empty() const -> bool
+{
+  return (length_z == 0 || length_y == 0 || length_x == 0);
 }
-  
+
 void sperr::SPECK3D_INT::m_clean_LIS()
 {
   for (auto& list : m_LIS) {

--- a/src/SPECK3D_INT_DEC.cpp
+++ b/src/SPECK3D_INT_DEC.cpp
@@ -7,8 +7,8 @@
 
 void sperr::SPECK3D_INT_DEC::decode()
 {
-  //if (m_ready_to_decode() == false)
-  //  return RTNType::Error;
+  // if (m_ready_to_decode() == false)
+  //   return RTNType::Error;
 
   m_initialize_lists();
 
@@ -18,7 +18,6 @@ void sperr::SPECK3D_INT_DEC::decode()
   m_sign_array.assign(coeff_len, true);
 
   // Mark every coefficient as insignificant
-  //m_LSP_mask.assign(m_coeff_buf.size(), false);
   m_LSP_mask.resize(m_coeff_buf.size());
   m_LSP_mask.reset();
   m_bit_itr = m_bit_buffer.cbegin();
@@ -36,7 +35,6 @@ void sperr::SPECK3D_INT_DEC::decode()
     m_clean_LIS();
   }
 }
-
 
 void sperr::SPECK3D_INT_DEC::m_sorting_pass()
 {
@@ -123,4 +121,3 @@ void sperr::SPECK3D_INT_DEC::m_code_S(size_t idx1, size_t idx2)
     }
   }
 }
-

--- a/src/SPECK3D_INT_DEC.cpp
+++ b/src/SPECK3D_INT_DEC.cpp
@@ -30,7 +30,7 @@ void sperr::SPECK3D_INT_DEC::decode()
 
   for (uint8_t bitplane = 0; bitplane < m_num_bitplanes; bitplane++) {
     m_sorting_pass();
-    m_refinement_pass();
+    m_refinement_pass_decode();
 
     m_threshold /= uint_t{2};
     m_clean_LIS();
@@ -54,38 +54,6 @@ void sperr::SPECK3D_INT_DEC::m_sorting_pass()
     for (size_t idx2 = 0; idx2 < m_LIS[idx1].size(); idx2++)
       m_process_S(idx1, idx2, dummy, true);
   }
-}
-
-void sperr::SPECK3D_INT_DEC::m_refinement_pass()
-{
-  // First, process significant pixels previously found.
-  //
-  const auto tmp = std::array<uint_t, 2>{uint_t{0}, m_threshold};
-
-  //for (size_t i = 0; i < m_LSP_mask.size(); i++) {
-  //  if (m_LSP_mask[i]) {
-  //    m_coeff_buf[i] += tmp[*m_bit_itr];
-  //    ++m_bit_itr;
-  //  }
-  //}
-  for (size_t i = 0; i < m_LSP_mask.size(); i += 64) {
-    const auto value = m_LSP_mask.read_long(i);
-    if (value != 0ul) {
-      for (size_t j = 0; j < 64ul; j++) {
-        if ((value >> j) & uint64_t(1ul)) {
-          m_coeff_buf[i + j] += tmp[*m_bit_itr];
-          ++m_bit_itr;
-        }
-      }
-    }
-  }
-
-  // Second, mark newly found significant pixels in `m_LSP_mark`
-  //
-  for (auto idx : m_LSP_new)
-    m_LSP_mask.write_bit(idx, true);
-    //m_LSP_mask[idx] = true;
-  m_LSP_new.clear();
 }
 
 void sperr::SPECK3D_INT_DEC::m_process_S(size_t idx1, size_t idx2, size_t& counter, bool read)

--- a/src/SPECK3D_INT_ENC.cpp
+++ b/src/SPECK3D_INT_ENC.cpp
@@ -75,7 +75,7 @@ void sperr::SPECK3D_INT_ENC::encode()
 
   for (uint8_t bitplane = 0; bitplane < m_num_bitplanes; bitplane++) {
     m_sorting_pass();
-    m_refinement_pass();
+    m_refinement_pass_encode();
 
     m_threshold /= uint_t{2};
     m_clean_LIS();
@@ -101,40 +101,6 @@ void sperr::SPECK3D_INT_ENC::m_sorting_pass()
     for (size_t idx2 = 0; idx2 < m_LIS[idx1].size(); idx2++)
       m_process_S(idx1, idx2, SigType::Dunno, dummy, true);
   }
-}
-
-void sperr::SPECK3D_INT_ENC::m_refinement_pass()
-{
-  // First, process significant pixels previously found.
-  //
-  const auto tmp1 = std::array<uint_t, 2>{0, m_threshold};
-
-  //for (size_t i = 0; i < m_LSP_mask.size(); i++) {
-  //  if (m_LSP_mask[i]) {
-  //    const bool o1 = m_coeff_buf[i] >= m_threshold;
-  //    m_bit_buffer.push_back(o1);
-  //    m_coeff_buf[i] -= tmp1[o1];
-  //  }
-  //}
-  for (size_t i = 0; i < m_LSP_mask.size(); i += 64) {
-    const auto value = m_LSP_mask.read_long(i);
-    if (value != 0ul) {
-      for (size_t j = 0; j < 64ul; j++) {
-        if ((value >> j) & uint64_t(1ul)) {
-          const bool o1 = m_coeff_buf[i + j] >= m_threshold;
-          m_bit_buffer.push_back(o1);
-          m_coeff_buf[i + j] -= tmp1[o1];
-        }
-      }
-    }
-  }
-
-  // Second, mark newly found significant pixels in `m_LSP_mask`.
-  //
-  for (auto idx : m_LSP_new)
-    m_LSP_mask.write_bit(idx, true);
-    //m_LSP_mask[idx] = true;
-  m_LSP_new.clear();
 }
 
 void sperr::SPECK3D_INT_ENC::m_process_S(size_t idx1,

--- a/src/SPECK3D_INT_ENC.cpp
+++ b/src/SPECK3D_INT_ENC.cpp
@@ -44,7 +44,9 @@ void sperr::SPECK3D_INT_ENC::encode()
   //  m_qz_coeff.clear();
 
   // Mark every coefficient as insignificant
-  m_LSP_mask.assign(m_coeff_buf.size(), false);
+  //m_LSP_mask.assign(m_coeff_buf.size(), false);
+  m_LSP_mask.resize(m_coeff_buf.size());
+  m_LSP_mask.reset();
 
   // Decide the starting threshold.
   const auto max_coeff = *std::max_element(m_coeff_buf.cbegin(), m_coeff_buf.cend());
@@ -107,18 +109,31 @@ void sperr::SPECK3D_INT_ENC::m_refinement_pass()
   //
   const auto tmp1 = std::array<uint_t, 2>{0, m_threshold};
 
-  for (size_t i = 0; i < m_LSP_mask.size(); i++) {
-    if (m_LSP_mask[i]) {
-      const bool o1 = m_coeff_buf[i] >= m_threshold;
-      m_bit_buffer.push_back(o1);
-      m_coeff_buf[i] -= tmp1[o1];
+  //for (size_t i = 0; i < m_LSP_mask.size(); i++) {
+  //  if (m_LSP_mask[i]) {
+  //    const bool o1 = m_coeff_buf[i] >= m_threshold;
+  //    m_bit_buffer.push_back(o1);
+  //    m_coeff_buf[i] -= tmp1[o1];
+  //  }
+  //}
+  for (size_t i = 0; i < m_LSP_mask.size(); i += 64) {
+    const auto value = m_LSP_mask.read_long(i);
+    if (value != 0ul) {
+      for (size_t j = 0; j < 64ul; j++) {
+        if ((value >> j) & uint64_t(1ul)) {
+          const bool o1 = m_coeff_buf[i + j] >= m_threshold;
+          m_bit_buffer.push_back(o1);
+          m_coeff_buf[i + j] -= tmp1[o1];
+        }
+      }
     }
   }
 
   // Second, mark newly found significant pixels in `m_LSP_mask`.
   //
   for (auto idx : m_LSP_new)
-    m_LSP_mask[idx] = true;
+    m_LSP_mask.write_bit(idx, true);
+    //m_LSP_mask[idx] = true;
   m_LSP_new.clear();
 }
 

--- a/src/SPECK3D_INT_ENC.cpp
+++ b/src/SPECK3D_INT_ENC.cpp
@@ -44,7 +44,6 @@ void sperr::SPECK3D_INT_ENC::encode()
   //  m_qz_coeff.clear();
 
   // Mark every coefficient as insignificant
-  //m_LSP_mask.assign(m_coeff_buf.size(), false);
   m_LSP_mask.resize(m_coeff_buf.size());
   m_LSP_mask.reset();
 

--- a/src/SPECK_INT.cpp
+++ b/src/SPECK_INT.cpp
@@ -122,7 +122,7 @@ void sperr::SPECK_INT::m_assemble_bitstream()
 void sperr::SPECK_INT::m_refinement_pass_encode()
 {
   // First, process significant pixels previously found.
-  //  
+  //
   const auto tmp1 = std::array<uint_t, 2>{uint_t{0}, m_threshold};
 
   for (size_t i = 0; i < m_LSP_mask.size(); i += 64) {
@@ -134,12 +134,12 @@ void sperr::SPECK_INT::m_refinement_pass_encode()
           m_coeff_buf[i + j] -= tmp1[o1];
           m_bit_buffer.push_back(o1);
         }
-      }   
-    }   
+      }
+    }
   }
 
   // Second, mark newly found significant pixels in `m_LSP_mask`.
-  //  
+  //
   for (auto idx : m_LSP_new)
     m_LSP_mask.write_bit(idx, true);
   m_LSP_new.clear();
@@ -148,7 +148,7 @@ void sperr::SPECK_INT::m_refinement_pass_encode()
 void sperr::SPECK_INT::m_refinement_pass_decode()
 {
   // First, process significant pixels previously found.
-  //  
+  //
   const auto tmp = std::array<uint_t, 2>{uint_t{0}, m_threshold};
 
   for (size_t i = 0; i < m_LSP_mask.size(); i += 64) {
@@ -158,15 +158,14 @@ void sperr::SPECK_INT::m_refinement_pass_decode()
         if ((value >> j) & uint64_t{1}) {
           m_coeff_buf[i + j] += tmp[*m_bit_itr];
           ++m_bit_itr;
-        }   
-      }   
+        }
+      }
     }
   }
 
   // Second, mark newly found significant pixels in `m_LSP_mask`
-  //  
+  //
   for (auto idx : m_LSP_new)
     m_LSP_mask.write_bit(idx, true);
   m_LSP_new.clear();
 }
-

--- a/src/SPECK_INT.cpp
+++ b/src/SPECK_INT.cpp
@@ -119,5 +119,54 @@ void sperr::SPECK_INT::m_assemble_bitstream()
   m_bit_buffer.resize(useful_bits);
 }
 
+void sperr::SPECK_INT::m_refinement_pass_encode()
+{
+  // First, process significant pixels previously found.
+  //  
+  const auto tmp1 = std::array<uint_t, 2>{uint_t{0}, m_threshold};
 
+  for (size_t i = 0; i < m_LSP_mask.size(); i += 64) {
+    const auto value = m_LSP_mask.read_long(i);
+    if (value != 0) {
+      for (size_t j = 0; j < 64; j++) {
+        if ((value >> j) & uint64_t{1}) {
+          const bool o1 = m_coeff_buf[i + j] >= m_threshold;
+          m_coeff_buf[i + j] -= tmp1[o1];
+          m_bit_buffer.push_back(o1);
+        }
+      }   
+    }   
+  }
+
+  // Second, mark newly found significant pixels in `m_LSP_mask`.
+  //  
+  for (auto idx : m_LSP_new)
+    m_LSP_mask.write_bit(idx, true);
+  m_LSP_new.clear();
+}
+
+void sperr::SPECK_INT::m_refinement_pass_decode()
+{
+  // First, process significant pixels previously found.
+  //  
+  const auto tmp = std::array<uint_t, 2>{uint_t{0}, m_threshold};
+
+  for (size_t i = 0; i < m_LSP_mask.size(); i += 64) {
+    const auto value = m_LSP_mask.read_long(i);
+    if (value != 0) {
+      for (size_t j = 0; j < 64; j++) {
+        if ((value >> j) & uint64_t{1}) {
+          m_coeff_buf[i + j] += tmp[*m_bit_itr];
+          ++m_bit_itr;
+        }   
+      }   
+    }
+  }
+
+  // Second, mark newly found significant pixels in `m_LSP_mask`
+  //  
+  for (auto idx : m_LSP_new)
+    m_LSP_mask.write_bit(idx, true);
+  m_LSP_new.clear();
+}
 

--- a/src/SPERR3D.cpp
+++ b/src/SPERR3D.cpp
@@ -1,6 +1,6 @@
 #include "SPERR3D.h"
-#include "SPECK3D_INT_ENC.h"
 #include "SPECK3D_INT_DEC.h"
+#include "SPECK3D_INT_ENC.h"
 
 //
 // Constructor
@@ -32,5 +32,3 @@ auto sperr::SPERR3D::m_inverse_quantize() -> RTNType
   m_midtread_i2f();
   return RTNType::Good;
 }
-
-

--- a/src/SPERR_Driver.cpp
+++ b/src/SPERR_Driver.cpp
@@ -147,7 +147,7 @@ auto sperr::SPERR_Driver::m_proc_2() -> RTNType
 
 auto sperr::SPERR_Driver::compress() -> RTNType
 {
-  const auto total_vals = m_dims[0] * m_dims[1] * m_dims[2];
+  const auto total_vals = uint64_t(m_dims[0]) * m_dims[1] * m_dims[2];
   if (m_vals_d.empty() || m_vals_d.size() != total_vals)
     return RTNType::Error;
 
@@ -196,7 +196,7 @@ auto sperr::SPERR_Driver::decompress() -> RTNType
   m_vals_ui.clear();
   m_vals_ll.clear();
   m_sign_array.clear();
-  const auto total_vals = m_dims[0] * m_dims[1] * m_dims[2];
+  const auto total_vals = uint64_t(m_dims[0]) * m_dims[1] * m_dims[2];
 
   // `m_condi_bitstream` might be indicating a constant field, so let's see if that's
   // the case, and if it is, we don't need to go through wavelet and speck stuff anymore.

--- a/src/SPERR_Driver.cpp
+++ b/src/SPERR_Driver.cpp
@@ -6,7 +6,6 @@
 #include <cmath>
 #include <cstring>
 
-
 template <typename T>
 void sperr::SPERR_Driver::copy_data(const T* p, size_t len)
 {
@@ -58,7 +57,7 @@ auto sperr::SPERR_Driver::use_bitstream(const void* p, size_t len) -> RTNType
   const uint8_t* const speck_p = ptr + pos;
   const auto speck_full_len = m_decoder->get_speck_full_len(speck_p);
   if (speck_full_len != len - pos)
-      return RTNType::BitstreamWrongLen;
+    return RTNType::BitstreamWrongLen;
   m_speck_bitstream.resize(speck_full_len);
   std::copy(speck_p, speck_p + speck_full_len, m_speck_bitstream.begin());
 
@@ -75,7 +74,7 @@ auto sperr::SPERR_Driver::get_encoded_bitstream() -> vec8_type
   const auto total_len = m_condi_bitstream.size() + m_speck_bitstream.size();
   auto tmp = vec8_type(total_len);
   std::copy(m_condi_bitstream.cbegin(), m_condi_bitstream.cend(), tmp.begin());
-  std::copy(m_speck_bitstream.cbegin(), m_speck_bitstream.cend(), 
+  std::copy(m_speck_bitstream.cbegin(), m_speck_bitstream.cend(),
             tmp.begin() + m_condi_bitstream.size());
   return tmp;
 }
@@ -97,7 +96,7 @@ void sperr::SPERR_Driver::set_dims(dims_type dims)
 
 auto sperr::SPERR_Driver::num_coded_vals() const -> size_t
 {
-  return std::count_if(m_vals_ll.cbegin(), m_vals_ll.cend(), [](auto v){ return v != 0l; });
+  return std::count_if(m_vals_ll.cbegin(), m_vals_ll.cend(), [](auto v) { return v != 0l; });
 }
 
 auto sperr::SPERR_Driver::m_midtread_f2i() -> RTNType
@@ -112,13 +111,13 @@ auto sperr::SPERR_Driver::m_midtread_f2i() -> RTNType
   std::fesetround(FE_TONEAREST);
   std::feclearexcept(FE_ALL_EXCEPT);
   std::transform(m_vals_d.cbegin(), m_vals_d.cend(), m_vals_ll.begin(),
-                 [q1](auto d){ return std::llrint(d * q1); });
+                 [q1](auto d) { return std::llrint(d * q1); });
   if (std::fetestexcept(FE_INVALID))
     return RTNType::FE_Invalid;
   std::transform(m_vals_ll.cbegin(), m_vals_ll.cend(), m_vals_ui.begin(),
-                 [](auto ll){ return static_cast<uint_t>(std::abs(ll)); });
+                 [](auto ll) { return static_cast<uint_t>(std::abs(ll)); });
   std::transform(m_vals_ll.cbegin(), m_vals_ll.cend(), m_sign_array.begin(),
-                 [](auto ll){ return ll >= 0ll; });
+                 [](auto ll) { return ll >= 0ll; });
 
   return RTNType::Good;
 }
@@ -131,8 +130,7 @@ void sperr::SPERR_Driver::m_midtread_i2f()
   const auto q = m_q;
   m_vals_d.resize(m_sign_array.size());
   std::transform(m_vals_ui.cbegin(), m_vals_ui.cend(), m_sign_array.cbegin(), m_vals_d.begin(),
-                 [tmpd, q](auto i, auto b){ return q * static_cast<double>(i) * tmpd[b]; });
-
+                 [tmpd, q](auto i, auto b) { return q * static_cast<double>(i) * tmpd[b]; });
 }
 
 auto sperr::SPERR_Driver::m_proc_1() -> RTNType
@@ -235,4 +233,3 @@ auto sperr::SPERR_Driver::decompress() -> RTNType
 
   return RTNType::Good;
 }
-

--- a/src/sperr_helper.cpp
+++ b/src/sperr_helper.cpp
@@ -45,7 +45,6 @@ auto sperr::calc_approx_detail_len(size_t orig_len, size_t lev) -> std::array<si
   return {low_len, high_len};
 }
 
-
 // Good solution to deal with bools and unsigned chars
 // https://stackoverflow.com/questions/8461126/how-to-create-a-byte-out-of-8-bool-values-and-vice-versa
 auto sperr::pack_booleans(std::vector<uint8_t>& dest, const std::vector<bool>& src, size_t offset)

--- a/src/zfp_bitstream.c
+++ b/src/zfp_bitstream.c
@@ -107,12 +107,13 @@ The following assumptions and restrictions apply:
 
 #include <limits.h>
 #include <stdlib.h>
+#include "zfp_bitstream.h"
+
+/* clang-format off */
 
 #ifndef inline_
   #define inline_
 #endif
-
-#include "zfp_bitstream.h"
 
 /* satisfy compiler when args unused */
 #define unused_(x) ((void)(x))
@@ -537,5 +538,7 @@ random_write_bit(bitstream* s, uint bit, bitstream_offset pos)
 /*
  * Finish Sam additions.
  */
+
+/* clang-format on */
 
 #undef unused_

--- a/src/zfp_bitstream.c
+++ b/src/zfp_bitstream.c
@@ -105,9 +105,9 @@ The following assumptions and restrictions apply:
    caught.
 */
 
+#include "zfp_bitstream.h"
 #include <limits.h>
 #include <stdlib.h>
-#include "zfp_bitstream.h"
 
 /* clang-format off */
 


### PR DESCRIPTION
This PR introduces a custom bitmask, Bitmask, and uses it for storage of data structure `m_LSP_mask`. Experiments show that this bitmask improves the runtime significantly across all platforms tested.

This PR also moves refinement pass implementation to the base SPECK_INT class. 