### PR TITLE
LIS mask

### DIFF
--- a/include/Bitmask.h
+++ b/include/Bitmask.h
@@ -44,6 +44,8 @@ class Bitmask {
   //
   void write_long(size_t idx, uint64_t value);
   void write_bit(size_t idx, bool bit);
+  void write_true(size_t idx);   // This is faster than `write_bit(idx, true)`.
+  void write_false(size_t idx);  // This is faster than `write_bit(idx, false)`.
 
   // Functions for direct access of the underlying data buffer
   // Note: `use_bitstream()` reads the number of values (uint64_t type) that provide

--- a/include/Outlier_Coder.h
+++ b/include/Outlier_Coder.h
@@ -1,9 +1,9 @@
 #ifndef OUTLIER_CODER_H
 #define OUTLIER_CODER_H
 
-#include "sperr_helper.h"
-#include "SPECK1D_INT_ENC.h"
 #include "SPECK1D_INT_DEC.h"
+#include "SPECK1D_INT_ENC.h"
+#include "sperr_helper.h"
 
 #include <variant>
 

--- a/include/SPECK1D_INT.h
+++ b/include/SPECK1D_INT.h
@@ -22,7 +22,7 @@ class SPECK1D_INT : public SPECK_INT<T> {
   //
   // Bring members from the base class to this derived class.
   //
-  using SPECK_INT<T>::m_LIP;
+  using SPECK_INT<T>::m_LIP_mask;
   using SPECK_INT<T>::m_LSP_new;
   using SPECK_INT<T>::m_dims;
   using SPECK_INT<T>::m_u64_garbage_val;

--- a/include/SPECK1D_INT_DEC.h
+++ b/include/SPECK1D_INT_DEC.h
@@ -14,7 +14,7 @@ class SPECK1D_INT_DEC : public SPECK1D_INT<T> {
   //
   // Bring members from parent classes to this derived class.
   //
-  using SPECK_INT<T>::m_LIP;
+  using SPECK_INT<T>::m_LIP_mask;
   using SPECK_INT<T>::m_LSP_new;
   using SPECK_INT<T>::m_bit_idx;
   using SPECK_INT<T>::m_threshold;

--- a/include/SPECK1D_INT_ENC.h
+++ b/include/SPECK1D_INT_ENC.h
@@ -16,7 +16,7 @@ class SPECK1D_INT_ENC : public SPECK1D_INT<T> {
   //
   // Bring members from parent classes to this derived class.
   //
-  using SPECK_INT<T>::m_LIP;
+  using SPECK_INT<T>::m_LIP_mask;
   using SPECK_INT<T>::m_LSP_new;
   using SPECK_INT<T>::m_threshold;
   using SPECK_INT<T>::m_coeff_buf;

--- a/include/SPECK3D_FLT.h
+++ b/include/SPECK3D_FLT.h
@@ -6,7 +6,6 @@
 namespace sperr {
 
 class SPECK3D_FLT : public SPECK_FLT {
-
  protected:
   void m_instantiate_encoder() override;
   void m_instantiate_decoder() override;

--- a/include/SPECK3D_INT.h
+++ b/include/SPECK3D_INT.h
@@ -38,7 +38,7 @@ class SPECK3D_INT : public SPECK_INT<T> {
   //
   // Bring members from the base class to this derived class.
   //
-  using SPECK_INT<T>::m_LIP;
+  using SPECK_INT<T>::m_LIP_mask;
   using SPECK_INT<T>::m_dims;
   using SPECK_INT<T>::m_LSP_new;
   using SPECK_INT<T>::m_coeff_buf;

--- a/include/SPECK3D_INT_DEC.h
+++ b/include/SPECK3D_INT_DEC.h
@@ -14,7 +14,7 @@ class SPECK3D_INT_DEC : public SPECK3D_INT<T> {
   //
   // Bring members from parent classes to this derived class.
   //
-  using SPECK_INT<T>::m_LIP;
+  using SPECK_INT<T>::m_LIP_mask;
   using SPECK_INT<T>::m_dims;
   using SPECK_INT<T>::m_LSP_new;
   using SPECK_INT<T>::m_bit_idx;

--- a/include/SPECK3D_INT_ENC.h
+++ b/include/SPECK3D_INT_ENC.h
@@ -16,7 +16,7 @@ class SPECK3D_INT_ENC : public SPECK3D_INT<T> {
   //
   // Bring members from parent classes to this derived class.
   //
-  using SPECK_INT<T>::m_LIP;
+  using SPECK_INT<T>::m_LIP_mask;
   using SPECK_INT<T>::m_dims;
   using SPECK_INT<T>::m_LSP_new;
   using SPECK_INT<T>::m_threshold;

--- a/include/SPECK_INT.h
+++ b/include/SPECK_INT.h
@@ -71,11 +71,11 @@ class SPECK_INT {
   // Data members
   dims_type m_dims = {0, 0, 0};
   uint_type m_threshold = 0;
-  Bitmask m_LSP_mask;
+  Bitmask m_LSP_mask, m_LIP_mask;
   vecui_type m_coeff_buf;
   vecb_type m_sign_array;
   Bitstream m_bit_buffer;
-  std::vector<uint64_t> m_LIP, m_LSP_new;
+  std::vector<uint64_t> m_LSP_new;
 
   const uint64_t m_u64_garbage_val = std::numeric_limits<uint64_t>::max();
   const size_t m_header_size = 9;  // 9 bytes

--- a/include/SPERR3D_OMP_D.h
+++ b/include/SPERR3D_OMP_D.h
@@ -53,9 +53,8 @@ class SPERR3D_OMP_D {
                        dims_type vol_dim,
                        const vecd_type& small_vol,
                        std::array<size_t, 6> chunk_info);
-
 };
 
-} // End of namespace sperr
+}  // End of namespace sperr
 
 #endif

--- a/include/sperr_helper.h
+++ b/include/sperr_helper.h
@@ -61,7 +61,7 @@ enum class RTNType {
   CompModeUnknown,
   CustomFilterMissing,
   CustomFilterError,
-  FE_Invalid, // floating point exception: FE_INVALID
+  FE_Invalid,  // floating point exception: FE_INVALID
   Error
 };
 

--- a/src/Bitmask.cpp
+++ b/src/Bitmask.cpp
@@ -58,13 +58,33 @@ void sperr::Bitmask::write_long(size_t idx, uint64_t value)
 void sperr::Bitmask::write_bit(size_t idx, bool bit)
 {
   const auto wstart = idx / 64;
+  const auto mask = uint64_t{1} << (idx % 64);
 
   auto word = m_buf[wstart];
-  const auto mask = uint64_t{1} << (idx % 64);
   if (bit)
     word |= mask;
   else
     word &= ~mask;
+  m_buf[wstart] = word;
+}
+
+void sperr::Bitmask::write_true(size_t idx)
+{
+  const auto wstart = idx / 64;
+  const auto mask = uint64_t{1} << (idx % 64);
+
+  auto word = m_buf[wstart];
+  word |= mask;
+  m_buf[wstart] = word;
+}
+
+void sperr::Bitmask::write_false(size_t idx)
+{
+  const auto wstart = idx / 64;
+  const auto mask = uint64_t{1} << (idx % 64);
+
+  auto word = m_buf[wstart];
+  word &= ~mask;
   m_buf[wstart] = word;
 }
 

--- a/src/SPECK1D_INT.cpp
+++ b/src/SPECK1D_INT.cpp
@@ -13,10 +13,6 @@ void sperr::SPECK1D_INT<T>::m_clean_LIS()
                              [](const auto& s) { return s.type == SetType::Garbage; });
     list.erase(it, list.end());
   }
-
-  // Let's also clean up m_LIP.
-  auto it = std::remove(m_LIP.begin(), m_LIP.end(), m_u64_garbage_val);
-  m_LIP.erase(it, m_LIP.end());
 }
 
 template <typename T>
@@ -28,9 +24,9 @@ void sperr::SPECK1D_INT<T>::m_initialize_lists()
   if (m_LIS.size() < num_of_lists)
     m_LIS.resize(num_of_lists);
   std::for_each(m_LIS.begin(), m_LIS.end(), [](auto& list) { list.clear(); });
-  m_LIP.clear();  // Costly mistake to forget to clean this list...
-  m_LIP.reserve(m_coeff_buf.size() / 32);
   m_LSP_new.clear();
+  m_LIP_mask.resize(m_coeff_buf.size());
+  m_LIP_mask.reset();
 
   // Put in two sets, each representing a half of the long array.
   Set1D set;

--- a/src/SPECK1D_INT.cpp
+++ b/src/SPECK1D_INT.cpp
@@ -25,7 +25,7 @@ void sperr::SPECK1D_INT<T>::m_initialize_lists()
     m_LIS.resize(num_of_lists);
   std::for_each(m_LIS.begin(), m_LIS.end(), [](auto& list) { list.clear(); });
   m_LSP_new.clear();
-  m_LIP_mask.resize(m_coeff_buf.size());
+  m_LIP_mask.resize(total_len);
   m_LIP_mask.reset();
 
   // Put in two sets, each representing a half of the long array.

--- a/src/SPECK1D_INT_DEC.cpp
+++ b/src/SPECK1D_INT_DEC.cpp
@@ -10,25 +10,23 @@ void sperr::SPECK1D_INT_DEC<T>::m_sorting_pass()
 {
   // Since we have a separate representation of LIP, let's process that list first
   //
-  if (m_LIP_mask.size() % 64 == 0) {
-    for (size_t i = 0; i < m_LIP_mask.size(); i += 64) {
-      const auto value = m_LIP_mask.read_long(i);
-      if (value != 0) {
-        for (size_t j = 0; j < 64; j++) {
-          if ((value >> j) & uint64_t{1}) {
-            size_t dummy = 0;
-            m_process_P(i + j, dummy, true);
-          }
+  const auto bits_x64 = m_LIP_mask.size() - m_LIP_mask.size() % 64;
+
+  for (size_t i = 0; i < bits_x64; i += 64) {
+    const auto value = m_LIP_mask.read_long(i);
+    if (value != 0) {
+      for (size_t j = 0; j < 64; j++) {
+        if ((value >> j) & uint64_t{1}) {
+          size_t dummy = 0;
+          m_process_P(i + j, dummy, true);
         }
-      }  // Finish examine 64 bits.
+      }
     }
   }
-  else {  // Very unlikely
-    for (size_t i = 0; i < m_LIP_mask.size(); i++) {
-      if (m_LIP_mask.read_bit(i)) {
-        size_t dummy = 0;
-        m_process_P(i, dummy, true);
-      }
+  for (auto i = bits_x64; i < m_LIP_mask.size(); i++) {
+    if (m_LIP_mask.read_bit(i)) {
+      size_t dummy = 0;
+      m_process_P(i, dummy, true);
     }
   }
 

--- a/src/SPECK1D_INT_DEC.cpp
+++ b/src/SPECK1D_INT_DEC.cpp
@@ -20,7 +20,7 @@ void sperr::SPECK1D_INT_DEC<T>::m_sorting_pass()
             m_process_P(i + j, dummy, true);
           }
         }
-      }
+      }  // Finish examine 64 bits.
     }
   }
   else {  // Very unlikely

--- a/src/SPECK1D_INT_ENC.cpp
+++ b/src/SPECK1D_INT_ENC.cpp
@@ -15,10 +15,12 @@ void sperr::SPECK1D_INT_ENC<T>::m_sorting_pass()
       const auto value = m_LIP_mask.read_long(i);
       if (value != 0) {
         for (size_t j = 0; j < 64; j++) {
-          size_t dummy = 0;
-          m_process_P(i + j, SigType::Dunno, dummy, true);
+          if ((value >> j) & uint64_t{1}) {
+            size_t dummy = 0;
+            m_process_P(i + j, SigType::Dunno, dummy, true);
+          }
         }
-      }
+      }  // Finish examine 64 bits.
     }
   }
   else {  // Very unlikely

--- a/src/SPECK1D_INT_ENC.cpp
+++ b/src/SPECK1D_INT_ENC.cpp
@@ -10,17 +10,35 @@ void sperr::SPECK1D_INT_ENC<T>::m_sorting_pass()
 {
   // Since we have a separate representation of LIP, let's process that list first!
   //
-  size_t dummy = 0;
-  for (size_t loc = 0; loc < m_LIP.size(); loc++)
-    m_process_P(loc, SigType::Dunno, dummy, true);
+  if (m_LIP_mask.size() % 64 == 0) {
+    for (size_t i = 0; i < m_LIP_mask.size(); i += 64) {
+      const auto value = m_LIP_mask.read_long(i);
+      if (value != 0) {
+        for (size_t j = 0; j < 64; j++) {
+          size_t dummy = 0;
+          m_process_P(i + j, SigType::Dunno, dummy, true);
+        }
+      }
+    }
+  }
+  else {  // Very unlikely
+    for (size_t i = 0; i < m_LIP_mask.size(); i++) {
+      if (m_LIP_mask.read_bit(i)) {
+        size_t dummy = 0;
+        m_process_P(i, SigType::Dunno, dummy, true);
+      }
+    }
+  }
 
   // Then we process regular sets in LIS.
   //
   for (size_t tmp = 1; tmp <= m_LIS.size(); tmp++) {
     // From the end of m_LIS to its front
     size_t idx1 = m_LIS.size() - tmp;
-    for (size_t idx2 = 0; idx2 < m_LIS[idx1].size(); idx2++)
+    for (size_t idx2 = 0; idx2 < m_LIS[idx1].size(); idx2++) {
+      size_t dummy = 0;
       m_process_S(idx1, idx2, SigType::Dunno, dummy, true);
+    }
   }
 }
 
@@ -67,15 +85,13 @@ void sperr::SPECK1D_INT_ENC<T>::m_process_S(size_t idx1,
 }
 
 template <typename T>
-void sperr::SPECK1D_INT_ENC<T>::m_process_P(size_t loc, SigType sig, size_t& counter, bool output)
+void sperr::SPECK1D_INT_ENC<T>::m_process_P(size_t idx, SigType sig, size_t& counter, bool output)
 {
-  const auto pixel_idx = m_LIP[loc];
-
   // Decide the significance of this pixel
   assert(sig != SigType::NewlySig);
   bool is_sig = false;
   if (sig == SigType::Dunno)
-    is_sig = (m_coeff_buf[pixel_idx] >= m_threshold);
+    is_sig = (m_coeff_buf[idx] >= m_threshold);
   else
     is_sig = (sig == SigType::Sig);
 
@@ -84,12 +100,12 @@ void sperr::SPECK1D_INT_ENC<T>::m_process_P(size_t loc, SigType sig, size_t& cou
 
   if (is_sig) {
     counter++;  // Let's increment the counter first!
-    m_bit_buffer.wbit(m_sign_array[pixel_idx]);
+    m_bit_buffer.wbit(m_sign_array[idx]);
 
-    assert(m_coeff_buf[pixel_idx] >= m_threshold);
-    m_coeff_buf[pixel_idx] -= m_threshold;
-    m_LSP_new.push_back(pixel_idx);
-    m_LIP[loc] = m_u64_garbage_val;
+    assert(m_coeff_buf[idx] >= m_threshold);
+    m_coeff_buf[idx] -= m_threshold;
+    m_LSP_new.push_back(idx);
+    m_LIP_mask.write_false(idx);
   }
 }
 
@@ -106,8 +122,8 @@ void sperr::SPECK1D_INT_ENC<T>::m_code_S(size_t idx1,
   const auto& set0 = subsets[0];
   assert(set0.length != 0);
   if (set0.length == 1) {
-    m_LIP.push_back(set0.start);
-    m_process_P(m_LIP.size() - 1, subset_sigs[0], sig_counter, output);
+    m_LIP_mask.write_true(set0.start);
+    m_process_P(set0.start, subset_sigs[0], sig_counter, output);
   }
   else {
     const auto newidx1 = set0.part_level;
@@ -124,8 +140,8 @@ void sperr::SPECK1D_INT_ENC<T>::m_code_S(size_t idx1,
   const auto& set1 = subsets[1];
   assert(set1.length != 0);
   if (set1.length == 1) {
-    m_LIP.push_back(set1.start);
-    m_process_P(m_LIP.size() - 1, subset_sigs[1], sig_counter, output);
+    m_LIP_mask.write_true(set1.start);
+    m_process_P(set1.start, subset_sigs[1], sig_counter, output);
   }
   else {
     const auto newidx1 = set1.part_level;

--- a/src/SPECK1D_INT_ENC.cpp
+++ b/src/SPECK1D_INT_ENC.cpp
@@ -10,25 +10,23 @@ void sperr::SPECK1D_INT_ENC<T>::m_sorting_pass()
 {
   // Since we have a separate representation of LIP, let's process that list first!
   //
-  if (m_LIP_mask.size() % 64 == 0) {
-    for (size_t i = 0; i < m_LIP_mask.size(); i += 64) {
-      const auto value = m_LIP_mask.read_long(i);
-      if (value != 0) {
-        for (size_t j = 0; j < 64; j++) {
-          if ((value >> j) & uint64_t{1}) {
-            size_t dummy = 0;
-            m_process_P(i + j, SigType::Dunno, dummy, true);
-          }
+  const auto bits_x64 = m_LIP_mask.size() - m_LIP_mask.size() % 64;
+
+  for (size_t i = 0; i < bits_x64; i += 64) {
+    const auto value = m_LIP_mask.read_long(i);
+    if (value != 0) {
+      for (size_t j = 0; j < 64; j++) {
+        if ((value >> j) & uint64_t{1}) {
+          size_t dummy = 0;
+          m_process_P(i + j, SigType::Dunno, dummy, true);
         }
-      }  // Finish examine 64 bits.
+      }
     }
   }
-  else {  // Very unlikely
-    for (size_t i = 0; i < m_LIP_mask.size(); i++) {
-      if (m_LIP_mask.read_bit(i)) {
-        size_t dummy = 0;
-        m_process_P(i, SigType::Dunno, dummy, true);
-      }
+  for (auto i = bits_x64; i < m_LIP_mask.size(); i++) {
+    if (m_LIP_mask.read_bit(i)) {
+      size_t dummy = 0;
+      m_process_P(i, SigType::Dunno, dummy, true);
     }
   }
 

--- a/src/SPECK3D_INT.cpp
+++ b/src/SPECK3D_INT.cpp
@@ -35,10 +35,12 @@ void sperr::SPECK3D_INT<T>::m_initialize_lists()
   size_t num_of_sizes = std::accumulate(num_of_parts.cbegin(), num_of_parts.cend(), 1ul);
 
   // Initialize LIS
+  const auto total_vals = m_dims[0] * m_dims[1] * m_dims[2];
+  assert(total_vals >= 0);
   if (m_LIS.size() < num_of_sizes)
     m_LIS.resize(num_of_sizes);
   std::for_each(m_LIS.begin(), m_LIS.end(), [](auto& list) { list.clear(); });
-  m_LIP_mask.resize(m_coeff_buf.size());
+  m_LIP_mask.resize(total_vals);
   m_LIP_mask.reset();
 
   // Starting from a set representing the whole volume, identify the smaller
@@ -91,8 +93,7 @@ void sperr::SPECK3D_INT<T>::m_initialize_lists()
   m_LIS[parts].insert(m_LIS[parts].begin(), big);
 
   m_LSP_new.clear();
-  m_LSP_new.reserve(m_coeff_buf.size() / 8);
-  m_bit_buffer.reserve(m_coeff_buf.size());  // a reasonable starting point
+  m_LSP_new.reserve(total_vals / 8);
 }
 
 template <typename T>

--- a/src/SPECK3D_INT.cpp
+++ b/src/SPECK3D_INT.cpp
@@ -23,10 +23,6 @@ void sperr::SPECK3D_INT<T>::m_clean_LIS()
                              [](const auto& s) { return s.type == SetType::Garbage; });
     list.erase(it, list.end());
   }
-
-  // Let's also clean up m_LIP.
-  auto it = std::remove(m_LIP.begin(), m_LIP.end(), m_u64_garbage_val);
-  m_LIP.erase(it, m_LIP.end());
 }
 
 template <typename T>
@@ -42,8 +38,8 @@ void sperr::SPECK3D_INT<T>::m_initialize_lists()
   if (m_LIS.size() < num_of_sizes)
     m_LIS.resize(num_of_sizes);
   std::for_each(m_LIS.begin(), m_LIS.end(), [](auto& list) { list.clear(); });
-  m_LIP.clear();
-  m_LIP.reserve(m_coeff_buf.size() / 4);
+  m_LIP_mask.resize(m_coeff_buf.size());
+  m_LIP_mask.reset();
 
   // Starting from a set representing the whole volume, identify the smaller
   // sets and put them in LIS accordingly.

--- a/src/SPECK3D_INT_DEC.cpp
+++ b/src/SPECK3D_INT_DEC.cpp
@@ -10,17 +10,37 @@ void sperr::SPECK3D_INT_DEC<T>::m_sorting_pass()
 {
   // Since we have a separate representation of LIP, let's process that list first
   //
-  size_t dummy = 0;
-  for (size_t loc = 0; loc < m_LIP.size(); loc++)
-    m_process_P(loc, dummy, true);
+  if (m_LIP_mask.size() % 64 == 0) {
+    for (size_t i = 0; i < m_LIP_mask.size(); i += 64) {
+      const auto value = m_LIP_mask.read_long(i);
+      if (value != 0) {
+        for (size_t j = 0; j < 64; j++) {
+          if ((value >> j) & uint64_t{1}) {
+            size_t dummy = 0;
+            m_process_P(i + j, dummy, true);
+          }
+        }
+      }
+    }
+  }
+  else {  // Very unlikely
+    for (size_t i = 0; i < m_LIP_mask.size(); i++) {
+      if (m_LIP_mask.read_bit(i)) {
+        size_t dummy = 0;
+        m_process_P(i, dummy, true);
+      }
+    }
+  }
 
   // Then we process regular sets in LIS.
   //
   for (size_t tmp = 1; tmp <= m_LIS.size(); tmp++) {
     // From the end of m_LIS to its front
     size_t idx1 = m_LIS.size() - tmp;
-    for (size_t idx2 = 0; idx2 < m_LIS[idx1].size(); idx2++)
+    for (size_t idx2 = 0; idx2 < m_LIS[idx1].size(); idx2++) {
+      size_t dummy = 0;
       m_process_S(idx1, idx2, dummy, true);
+    }
   }
 }
 
@@ -44,10 +64,9 @@ void sperr::SPECK3D_INT_DEC<T>::m_process_S(size_t idx1, size_t idx2, size_t& co
 }
 
 template <typename T>
-void sperr::SPECK3D_INT_DEC<T>::m_process_P(size_t loc, size_t& counter, bool read)
+void sperr::SPECK3D_INT_DEC<T>::m_process_P(size_t idx, size_t& counter, bool read)
 {
   bool is_sig = true;
-  const auto pixel_idx = m_LIP[loc];
 
   if (read) {
     is_sig = m_bit_buffer.rbit();
@@ -56,13 +75,12 @@ void sperr::SPECK3D_INT_DEC<T>::m_process_P(size_t loc, size_t& counter, bool re
 
   if (is_sig) {
     counter++;  // Let's increment the counter first!
-    m_sign_array[pixel_idx] = m_bit_buffer.rbit();
+    m_sign_array[idx] = m_bit_buffer.rbit();
     ++m_bit_idx;
 
-    m_coeff_buf[pixel_idx] = m_threshold;
-    m_LSP_new.push_back(pixel_idx);
-
-    m_LIP[loc] = m_u64_garbage_val;
+    m_coeff_buf[idx] = m_threshold;
+    m_LSP_new.push_back(idx);
+    m_LIP_mask.write_false(idx);
   }
 }
 
@@ -83,8 +101,9 @@ void sperr::SPECK3D_INT_DEC<T>::m_code_S(size_t idx1, size_t idx2)
       read = false;
     }
     if (it->is_pixel()) {
-      m_LIP.push_back(it->start_z * m_dims[0] * m_dims[1] + it->start_y * m_dims[0] + it->start_x);
-      m_process_P(m_LIP.size() - 1, sig_counter, read);
+      auto idx = it->start_z * m_dims[0] * m_dims[1] + it->start_y * m_dims[0] + it->start_x;
+      m_LIP_mask.write_true(idx);
+      m_process_P(idx, sig_counter, read);
     }
     else {
       const auto newidx1 = it->part_level;

--- a/src/SPECK3D_INT_DEC.cpp
+++ b/src/SPECK3D_INT_DEC.cpp
@@ -10,25 +10,23 @@ void sperr::SPECK3D_INT_DEC<T>::m_sorting_pass()
 {
   // Since we have a separate representation of LIP, let's process that list first
   //
-  if (m_LIP_mask.size() % 64 == 0) {
-    for (size_t i = 0; i < m_LIP_mask.size(); i += 64) {
-      const auto value = m_LIP_mask.read_long(i);
-      if (value != 0) {
-        for (size_t j = 0; j < 64; j++) {
-          if ((value >> j) & uint64_t{1}) {
-            size_t dummy = 0;
-            m_process_P(i + j, dummy, true);
-          }
+  const auto bits_x64 = m_LIP_mask.size() - m_LIP_mask.size() % 64;
+
+  for (size_t i = 0; i < bits_x64; i += 64) {
+    const auto value = m_LIP_mask.read_long(i);
+    if (value != 0) {
+      for (size_t j = 0; j < 64; j++) {
+        if ((value >> j) & uint64_t{1}) {
+          size_t dummy = 0;
+          m_process_P(i + j, dummy, true);
         }
-      }  // Finish examine 64 bits.
+      }
     }
   }
-  else {  // Very unlikely
-    for (size_t i = 0; i < m_LIP_mask.size(); i++) {
-      if (m_LIP_mask.read_bit(i)) {
-        size_t dummy = 0;
-        m_process_P(i, dummy, true);
-      }
+  for (auto i = bits_x64; i < m_LIP_mask.size(); i++) {
+    if (m_LIP_mask.read_bit(i)) {
+      size_t dummy = 0;
+      m_process_P(i, dummy, true);
     }
   }
 

--- a/src/SPECK3D_INT_DEC.cpp
+++ b/src/SPECK3D_INT_DEC.cpp
@@ -20,7 +20,7 @@ void sperr::SPECK3D_INT_DEC<T>::m_sorting_pass()
             m_process_P(i + j, dummy, true);
           }
         }
-      }
+      }  // Finish examine 64 bits.
     }
   }
   else {  // Very unlikely

--- a/src/SPECK3D_INT_ENC.cpp
+++ b/src/SPECK3D_INT_ENC.cpp
@@ -20,7 +20,7 @@ void sperr::SPECK3D_INT_ENC<T>::m_sorting_pass()
             m_process_P(i + j, SigType::Dunno, dummy, true);
           }
         }
-      }
+      }  // Finish examine 64 bits.
     }
   }
   else {  // Very unlikely

--- a/src/SPECK3D_INT_ENC.cpp
+++ b/src/SPECK3D_INT_ENC.cpp
@@ -137,7 +137,7 @@ void sperr::SPECK3D_INT_ENC<T>::m_code_S(size_t idx1,
     if (subsets[i].is_empty())
       subset_sigs[i] = SigType::Garbage;  // SigType::Garbage is only used locally here.
   }
-  std::remove(subset_sigs.begin(), subset_sigs.end(), SigType::Garbage);
+  auto sig_end = std::remove(subset_sigs.begin(), subset_sigs.end(), SigType::Garbage);
   const auto set_end =
       std::remove_if(subsets.begin(), subsets.end(), [](auto& s) { return s.is_empty(); });
   const auto set_end_m1 = set_end - 1;

--- a/src/SPECK3D_INT_ENC.cpp
+++ b/src/SPECK3D_INT_ENC.cpp
@@ -10,25 +10,23 @@ void sperr::SPECK3D_INT_ENC<T>::m_sorting_pass()
 {
   // Since we have a separate representation of LIP, let's process that list first!
   //
-  if (m_LIP_mask.size() % 64 == 0) {
-    for (size_t i = 0; i < m_LIP_mask.size(); i += 64) {
-      const auto value = m_LIP_mask.read_long(i);
-      if (value != 0) {
-        for (size_t j = 0; j < 64; j++) {
-          if ((value >> j) & uint64_t{1}) {
-            size_t dummy = 0;
-            m_process_P(i + j, SigType::Dunno, dummy, true);
-          }
+  const auto bits_x64 = m_LIP_mask.size() - m_LIP_mask.size() % 64;
+
+  for (size_t i = 0; i < bits_x64; i += 64) {
+    const auto value = m_LIP_mask.read_long(i);
+    if (value != 0) {
+      for (size_t j = 0; j < 64; j++) {
+        if ((value >> j) & uint64_t{1}) {
+          size_t dummy = 0;
+          m_process_P(i + j, SigType::Dunno, dummy, true);
         }
-      }  // Finish examine 64 bits.
+      }
     }
   }
-  else {  // Very unlikely
-    for (size_t i = 0; i < m_LIP_mask.size(); i++) {
-      if (m_LIP_mask.read_bit(i)) {
-        size_t dummy = 0;
-        m_process_P(i, SigType::Dunno, dummy, true);
-      }
+  for (auto i = bits_x64; i < m_LIP_mask.size(); i++) {
+    if (m_LIP_mask.read_bit(i)) {
+      size_t dummy = 0;
+      m_process_P(i, SigType::Dunno, dummy, true);
     }
   }
 

--- a/src/SPECK3D_INT_ENC.cpp
+++ b/src/SPECK3D_INT_ENC.cpp
@@ -10,17 +10,37 @@ void sperr::SPECK3D_INT_ENC<T>::m_sorting_pass()
 {
   // Since we have a separate representation of LIP, let's process that list first!
   //
-  size_t dummy = 0;
-  for (size_t loc = 0; loc < m_LIP.size(); loc++)
-    m_process_P(loc, SigType::Dunno, dummy, true);
+  if (m_LIP_mask.size() % 64 == 0) {
+    for (size_t i = 0; i < m_LIP_mask.size(); i += 64) {
+      const auto value = m_LIP_mask.read_long(i);
+      if (value != 0) {
+        for (size_t j = 0; j < 64; j++) {
+          if ((value >> j) & uint64_t{1}) {
+            size_t dummy = 0;
+            m_process_P(i + j, SigType::Dunno, dummy, true);
+          }
+        }
+      }
+    }
+  }
+  else {  // Very unlikely
+    for (size_t i = 0; i < m_LIP_mask.size(); i++) {
+      if (m_LIP_mask.read_bit(i)) {
+        size_t dummy = 0;
+        m_process_P(i, SigType::Dunno, dummy, true);
+      }
+    }
+  }
 
   // Then we process regular sets in LIS.
   //
   for (size_t tmp = 1; tmp <= m_LIS.size(); tmp++) {
     // From the end of m_LIS to its front
     size_t idx1 = m_LIS.size() - tmp;
-    for (size_t idx2 = 0; idx2 < m_LIS[idx1].size(); idx2++)
+    for (size_t idx2 = 0; idx2 < m_LIS[idx1].size(); idx2++) {
+      size_t dummy = 0;
       m_process_S(idx1, idx2, SigType::Dunno, dummy, true);
+    }
   }
 }
 
@@ -82,15 +102,13 @@ void sperr::SPECK3D_INT_ENC<T>::m_process_S(size_t idx1,
 }
 
 template <typename T>
-void sperr::SPECK3D_INT_ENC<T>::m_process_P(size_t loc, SigType sig, size_t& counter, bool output)
+void sperr::SPECK3D_INT_ENC<T>::m_process_P(size_t idx, SigType sig, size_t& counter, bool output)
 {
-  const auto pixel_idx = m_LIP[loc];
-
   // Decide the significance of this pixel
   assert(sig != SigType::NewlySig);
   bool is_sig = false;
   if (sig == SigType::Dunno)
-    is_sig = (m_coeff_buf[pixel_idx] >= m_threshold);
+    is_sig = (m_coeff_buf[idx] >= m_threshold);
   else
     is_sig = (sig == SigType::Sig);
 
@@ -99,12 +117,12 @@ void sperr::SPECK3D_INT_ENC<T>::m_process_P(size_t loc, SigType sig, size_t& cou
 
   if (is_sig) {
     counter++;  // Let's increment the counter first!
-    m_bit_buffer.wbit(m_sign_array[pixel_idx]);
+    m_bit_buffer.wbit(m_sign_array[idx]);
 
-    assert(m_coeff_buf[pixel_idx] >= m_threshold);
-    m_coeff_buf[pixel_idx] -= m_threshold;
-    m_LSP_new.push_back(pixel_idx);
-    m_LIP[loc] = m_u64_garbage_val;
+    assert(m_coeff_buf[idx] >= m_threshold);
+    m_coeff_buf[idx] -= m_threshold;
+    m_LSP_new.push_back(idx);
+    m_LIP_mask.write_false(idx);
   }
 }
 
@@ -138,8 +156,9 @@ void sperr::SPECK3D_INT_ENC<T>::m_code_S(size_t idx1,
     }
 
     if (it->is_pixel()) {
-      m_LIP.push_back(it->start_z * m_dims[0] * m_dims[1] + it->start_y * m_dims[0] + it->start_x);
-      m_process_P(m_LIP.size() - 1, *sig_it, sig_counter, output);
+      auto idx = it->start_z * m_dims[0] * m_dims[1] + it->start_y * m_dims[0] + it->start_x;
+      m_LIP_mask.write_true(idx);
+      m_process_P(idx, *sig_it, sig_counter, output);
     }
     else {
       const auto newidx1 = it->part_level;

--- a/src/SPECK_INT.cpp
+++ b/src/SPECK_INT.cpp
@@ -81,6 +81,7 @@ auto sperr::SPECK_INT<T>::get_stream_full_len(const void* buf) const -> uint64_t
 template <typename T>
 void sperr::SPECK_INT<T>::encode()
 {
+  m_bit_buffer.reserve(m_coeff_buf.size()); // A good starting point
   m_bit_buffer.rewind();
   m_total_bits = 0;
   m_initialize_lists();
@@ -131,7 +132,7 @@ void sperr::SPECK_INT<T>::decode()
   m_sign_array.assign(coeff_len, true);
 
   // Mark every coefficient as insignificant
-  m_LSP_mask.resize(m_coeff_buf.size());
+  m_LSP_mask.resize(coeff_len);
   m_LSP_mask.reset();
   m_bit_buffer.rewind();
   m_bit_idx = 0;

--- a/src/SPECK_INT.cpp
+++ b/src/SPECK_INT.cpp
@@ -242,28 +242,25 @@ void sperr::SPECK_INT<T>::m_refinement_pass_encode()
   // First, process significant pixels previously found.
   //
   const auto tmp1 = std::array<uint_type, 2>{uint_type{0}, m_threshold};
+  const auto bits_x64 = m_LSP_mask.size() - m_LSP_mask.size() % 64;
 
-  if (m_LSP_mask.size() % 64 == 0) {
-    for (size_t i = 0; i < m_LSP_mask.size(); i += 64) {
-      const auto value = m_LSP_mask.read_long(i);
-      if (value != 0) {
-        for (size_t j = 0; j < 64; j++) {
-          if ((value >> j) & uint64_t{1}) {
-            const bool o1 = m_coeff_buf[i + j] >= m_threshold;
-            m_coeff_buf[i + j] -= tmp1[o1];
-            m_bit_buffer.wbit(o1);
-          }
+  for (size_t i = 0; i < bits_x64; i += 64) {
+    const auto value = m_LSP_mask.read_long(i);
+    if (value != 0) {
+      for (size_t j = 0; j < 64; j++) {
+        if ((value >> j) & uint64_t{1}) {
+          const bool o1 = m_coeff_buf[i + j] >= m_threshold;
+          m_coeff_buf[i + j] -= tmp1[o1];
+          m_bit_buffer.wbit(o1);
         }
       }
     }
   }
-  else {  // Very unlikely
-    for (size_t i = 0; i < m_LSP_mask.size(); i++) {
-      if (m_LSP_mask.read_bit(i)) {
-        const bool o1 = m_coeff_buf[i] >= m_threshold;
-        m_coeff_buf[i] -= tmp1[o1];
-        m_bit_buffer.wbit(o1);
-      }
+  for (auto i = bits_x64; i < m_LSP_mask.size(); i++) {
+    if (m_LSP_mask.read_bit(i)) {
+      const bool o1 = m_coeff_buf[i] >= m_threshold;
+      m_coeff_buf[i] -= tmp1[o1];
+      m_bit_buffer.wbit(o1);
     }
   }
 
@@ -280,26 +277,23 @@ void sperr::SPECK_INT<T>::m_refinement_pass_decode()
   // First, process significant pixels previously found.
   //
   const auto tmp = std::array<uint_type, 2>{uint_type{0}, m_threshold};
+  const auto bits_x64 = m_LSP_mask.size() - m_LSP_mask.size() % 64;
 
-  if (m_LSP_mask.size() % 64 == 0) {
-    for (size_t i = 0; i < m_LSP_mask.size(); i += 64) {
-      const auto value = m_LSP_mask.read_long(i);
-      if (value != 0) {
-        for (size_t j = 0; j < 64; j++) {
-          if ((value >> j) & uint64_t{1}) {
-            m_coeff_buf[i + j] += tmp[m_bit_buffer.rbit()];
-            ++m_bit_idx;
-          }
+  for (size_t i = 0; i < bits_x64; i += 64) {
+    const auto value = m_LSP_mask.read_long(i);
+    if (value != 0) {
+      for (size_t j = 0; j < 64; j++) {
+        if ((value >> j) & uint64_t{1}) {
+          m_coeff_buf[i + j] += tmp[m_bit_buffer.rbit()];
+          ++m_bit_idx;
         }
       }
     }
   }
-  else {  // Very unlikely
-    for (size_t i = 0; i < m_LSP_mask.size(); i++) {
-      if (m_LSP_mask.read_bit(i)) {
-        m_coeff_buf[i] += tmp[m_bit_buffer.rbit()];
-        ++m_bit_idx;
-      }
+  for (auto i = bits_x64; i < m_LSP_mask.size(); i++) {
+    if (m_LSP_mask.read_bit(i)) {
+      m_coeff_buf[i] += tmp[m_bit_buffer.rbit()];
+      ++m_bit_idx;
     }
   }
   assert(m_bit_idx <= m_total_bits);

--- a/src/SPECK_INT.cpp
+++ b/src/SPECK_INT.cpp
@@ -81,7 +81,7 @@ auto sperr::SPECK_INT<T>::get_stream_full_len(const void* buf) const -> uint64_t
 template <typename T>
 void sperr::SPECK_INT<T>::encode()
 {
-  m_bit_buffer.reserve(m_coeff_buf.size()); // A good starting point
+  m_bit_buffer.reserve(m_coeff_buf.size());  // A good starting point
   m_bit_buffer.rewind();
   m_total_bits = 0;
   m_initialize_lists();
@@ -270,7 +270,7 @@ void sperr::SPECK_INT<T>::m_refinement_pass_encode()
   // Second, mark newly found significant pixels in `m_LSP_mask`.
   //
   for (auto idx : m_LSP_new)
-    m_LSP_mask.write_bit(idx, true);
+    m_LSP_mask.write_true(idx);
   m_LSP_new.clear();
 }
 
@@ -307,7 +307,7 @@ void sperr::SPECK_INT<T>::m_refinement_pass_decode()
   // Second, mark newly found significant pixels in `m_LSP_mask`
   //
   for (auto idx : m_LSP_new)
-    m_LSP_mask.write_bit(idx, true);
+    m_LSP_mask.write_true(idx);
   m_LSP_new.clear();
 }
 

--- a/test_scripts/bitstream_unit_test.cpp
+++ b/test_scripts/bitstream_unit_test.cpp
@@ -230,6 +230,16 @@ TEST(Bitmask, RandomReadWrite)
     m1.write_bit(i, ran);
     vec[i] = ran;
   }
+  for (size_t i = 1; i < N; i += 35) {
+    if (i % 2 == 0) { 
+      m1.write_true(i);
+      vec[i] = true;
+    }
+    else {
+      m1.write_false(i);
+      vec[i] = false;
+    }
+  }
   for (size_t i = 0; i < N; i++)
     EXPECT_EQ(m1.read_bit(i), vec[i]) << "at idx = " << i;
 }

--- a/test_scripts/speck_int_unit_test.cpp
+++ b/test_scripts/speck_int_unit_test.cpp
@@ -197,7 +197,7 @@ TEST(SPECK1D_INT, Random2)
   auto [input, input_signs] = ProduceRandomArray<uint16_t>(dims[0], 499.0, 2); 
 
   // Encode
-  auto encoder = sperr::SPECK3D_INT_ENC<uint16_t>();
+  auto encoder = sperr::SPECK1D_INT_ENC<uint16_t>();
   encoder.use_coeffs(input, input_signs);
   encoder.set_dims(dims);
   encoder.encode();
@@ -205,7 +205,7 @@ TEST(SPECK1D_INT, Random2)
   encoder.append_encoded_bitstream(bitstream);
 
   // Decode
-  auto decoder = sperr::SPECK3D_INT_DEC<uint16_t>();
+  auto decoder = sperr::SPECK1D_INT_DEC<uint16_t>();
   decoder.set_dims(dims);
   decoder.use_bitstream(bitstream.data(), bitstream.size());
   decoder.decode();
@@ -464,6 +464,5 @@ TEST(SPECK3D_INT, RandomRandom)
   EXPECT_EQ(input, output);
   EXPECT_EQ(input_signs, output_signs);
 }
-
 
 }  // namespace


### PR DESCRIPTION
This PR changes the implementation so all "insignificant points" are represented using a mask, rather than a list. The new implementation is more memory friendly, and it provides a 15% to 20% performance improvement. 