### PR TITLE
Improved progressive decoding

### DIFF
--- a/include/SPECK2D_INT_DEC.h
+++ b/include/SPECK2D_INT_DEC.h
@@ -21,7 +21,6 @@ class SPECK2D_INT_DEC : public SPECK2D_INT<T> {
   using SPECK_INT<T>::m_coeff_buf;
   using SPECK_INT<T>::m_bit_buffer;
   using SPECK_INT<T>::m_sign_array;
-  using SPECK_INT<T>::m_total_bits;
   using SPECK2D_INT<T>::m_LIS;
   using SPECK2D_INT<T>::m_I;
   using SPECK2D_INT<T>::m_code_S;

--- a/include/SPECK_FLT.h
+++ b/include/SPECK_FLT.h
@@ -108,11 +108,12 @@ class SPECK_FLT {
   // Estimate MSE assuming midtread quantization strategy.
   auto m_estimate_mse_midtread(double q) const -> double;
 
-  // The meaning of the input parameter differs depending on the compression mode:
-  //    - PWE:  it's not used, can be anything;
-  //    - PSNR: it must be the data range of the original input;
-  //    - Rate: it must be the biggest magnitude of transformed wavelet coefficients.
-  auto m_estimate_q(double) const -> double;
+  // The meaning of inputs `param` and `high_prec` differ depending on the compression mode:
+  //    - PWE:  no input is used; they can be anything;
+  //    - PSNR: `param` must be the data range of the original input; `high_prec` is not used;
+  //    - Rate: `param` must be the biggest magnitude of transformed wavelet coefficients;
+  //            `high_prec` should be false at first, and true if not enough bits are produced.
+  auto m_estimate_q(double param, bool high_prec) const -> double;
 };
 
 };  // namespace sperr

--- a/include/SPECK_INT.h
+++ b/include/SPECK_INT.h
@@ -69,8 +69,7 @@ class SPECK_INT {
   virtual void m_sorting_pass() = 0;
   virtual void m_initialize_lists() = 0;
   void m_refinement_pass_encode();
-  void m_refinement_pass_decode_complete();
-  auto m_refinement_pass_decode_partial() -> RTNType;
+  void m_refinement_pass_decode();
 
   // Data members
   dims_type m_dims = {0, 0, 0};

--- a/include/SPECK_INT.h
+++ b/include/SPECK_INT.h
@@ -57,6 +57,7 @@ class SPECK_INT {
   void use_bitstream(const void* p, size_t len);
 
   // Output
+  auto encoded_bitstream_len() const -> size_t;
   void append_encoded_bitstream(vec8_type& buf) const;
   auto release_coeffs() -> vecui_type&&;
   auto release_signs() -> vecb_type&&;

--- a/src/SPECK1D_INT_DEC.cpp
+++ b/src/SPECK1D_INT_DEC.cpp
@@ -70,7 +70,7 @@ void sperr::SPECK1D_INT_DEC<T>::m_process_P(size_t idx, size_t& counter, bool re
     counter++;  // Let's increment the counter first!
     m_sign_array[idx] = m_bit_buffer.rbit();
 
-    m_coeff_buf[idx] = m_threshold;
+    m_coeff_buf[idx] = m_threshold + m_threshold / T{2};
     m_LSP_new.push_back(idx);
     m_LIP_mask.write_false(idx);
   }

--- a/src/SPECK2D_INT_DEC.cpp
+++ b/src/SPECK2D_INT_DEC.cpp
@@ -12,10 +12,8 @@ void sperr::SPECK2D_INT_DEC<T>::m_process_S(size_t idx1,
   assert(!set.is_pixel());
   bool is_sig = true;
 
-  if (need_decide) {
-    assert(m_bit_buffer.rtell() < m_total_bits);
+  if (need_decide)
     is_sig = m_bit_buffer.rbit();
-  }
 
   if (is_sig) {
     counter++;
@@ -29,10 +27,8 @@ void sperr::SPECK2D_INT_DEC<T>::m_process_P(size_t idx, size_t& counter, bool ne
 {
   bool is_sig = true;
 
-  if (need_decide) {
-    assert(m_bit_buffer.rtell() < m_total_bits);
+  if (need_decide)
     is_sig = m_bit_buffer.rbit();
-  }
 
   if (is_sig) {
     counter++;
@@ -49,10 +45,8 @@ void sperr::SPECK2D_INT_DEC<T>::m_process_I(bool need_decide)
 {
   if (m_I.part_level > 0) {  // Only process `m_I` when it's not empty.
     bool is_sig = true;
-    if (need_decide) {
-      assert(m_bit_buffer.rtell() < m_total_bits);
+    if (need_decide)
       is_sig = m_bit_buffer.rbit();
-    }
     if (is_sig)
       m_code_I();
   }

--- a/src/SPECK2D_INT_DEC.cpp
+++ b/src/SPECK2D_INT_DEC.cpp
@@ -34,7 +34,7 @@ void sperr::SPECK2D_INT_DEC<T>::m_process_P(size_t idx, size_t& counter, bool ne
     counter++;
     m_sign_array[idx] = m_bit_buffer.rbit();
 
-    m_coeff_buf[idx] = m_threshold;
+    m_coeff_buf[idx] = m_threshold + m_threshold / T{2};
     m_LSP_new.push_back(idx);
     m_LIP_mask.write_false(idx);
   }

--- a/src/SPECK3D_INT_DEC.cpp
+++ b/src/SPECK3D_INT_DEC.cpp
@@ -71,7 +71,7 @@ void sperr::SPECK3D_INT_DEC<T>::m_process_P(size_t idx, size_t& counter, bool re
     counter++;  // Let's increment the counter first!
     m_sign_array[idx] = m_bit_buffer.rbit();
 
-    m_coeff_buf[idx] = m_threshold;
+    m_coeff_buf[idx] = m_threshold + m_threshold / T{2};
     m_LSP_new.push_back(idx);
     m_LIP_mask.write_false(idx);
   }

--- a/src/SPECK_FLT.cpp
+++ b/src/SPECK_FLT.cpp
@@ -266,9 +266,9 @@ auto sperr::SPECK_FLT::m_estimate_q(double param, bool high_prec) const -> doubl
       if (!high_prec) {
         return param / static_cast<double>(std::numeric_limits<uint32_t>::max());
       }
-      // This case is less frequent, and should only occur when a pretty high bitrate is requested.
+      // This case is less frequent, and it occurs when a rather high bitrate is requested.
       //    Here, we want to have the quantized values no bigger than the biggest (odd) int value
-      //    representable by double and sill has a precision of 1.0. Turns out that this value is
+      //    representable by double AND sill has a precision of 1.0. Turns out that this value is
       //    0x1.fffffffffffffp52, or in decimal 9007199254740991.0, or 9e15.
       //    File `utilities/double_prec.cpp` experiments with double precision approaching here,
       //    and more discussion can be found at:
@@ -473,8 +473,8 @@ FIXED_RATE_HIGH_PREC_LABEL:
   // Step 4: Integer SPECK encoding
   m_instantiate_encoder();
   if (m_mode == CompMode::Rate) {
-    auto total_bits = static_cast<size_t>(m_quality * double(total_vals));
-    std::visit([total_bits](auto&& encoder) { encoder->set_budget(total_bits); }, m_encoder);
+    auto budget = static_cast<size_t>(m_quality * double(total_vals));  // total num of bits
+    std::visit([budget](auto&& encoder) { encoder->set_budget(budget); }, m_encoder);
   }
   std::visit([&dims = m_dims](auto&& encoder) { encoder->set_dims(dims); }, m_encoder);
   switch (m_uint_flag) {
@@ -513,10 +513,10 @@ FIXED_RATE_HIGH_PREC_LABEL:
   //    is one place where it's making the code most clean and not introducing additional risks.
   //
   if (m_mode == CompMode::Rate && high_prec == false) {
-    auto target = static_cast<size_t>(m_quality * double(total_vals));
     assert(m_encoder.index() == 2);
+    auto budget = static_cast<size_t>(m_quality * double(total_vals));
     auto actual = std::get<2>(m_encoder)->encoded_bitstream_len() * size_t{8};
-    if (actual < target) {
+    if (actual < budget) {
       high_prec = true;
       goto FIXED_RATE_HIGH_PREC_LABEL;
     }

--- a/src/SPECK_FLT.cpp
+++ b/src/SPECK_FLT.cpp
@@ -258,10 +258,10 @@ auto sperr::SPECK_FLT::m_estimate_q(double param) const -> double
     case CompMode::PWE:
       return m_quality * 1.5;
     case CompMode::Rate:
-      // The biggest double (odd) value that sill has a precision of 1 is 0x1.fffffffffffffp52.
+      // The biggest (odd) double value that sill has a precision of 1 is 0x1.fffffffffffffp52.
       //    In decimal it's 9007199254740991.0, or approx. 9e15. Given the largest wavelet
-      //    coefficient, we set `m_q` so that the quantized integer is this 0x1p53 - 1.0.  File
-      //    `utilities/double_prec.cpp` experiments with double precision approaching here,
+      //    coefficient, we set `m_q` so that the quantized integer is this 0x1.fffffffffffffp52.
+      //    File `utilities/double_prec.cpp` experiments with double precision approaching here,
       //    and more discussion can be found at:
       //    https://randomascii.wordpress.com/2012/01/11/tricks-with-the-floating-point-format/
       return param / 0x1.fffffffffffffp52;

--- a/src/SPECK_FLT.cpp
+++ b/src/SPECK_FLT.cpp
@@ -511,10 +511,11 @@ FIXED_RATE_HIGH_PREC_LABEL:
   //    so quantiztion is done with a higher precision.
   //    Btw I know that GOTO should be used very sparsely and with great caution. I think this
   //    is one place where it's making the code most clean and not introducing additional risks.
+  //
   if (m_mode == CompMode::Rate && high_prec == false) {
     auto target = static_cast<size_t>(m_quality * double(total_vals));
     assert(m_encoder.index() == 2);
-    auto actual = std::get<2>(m_encoder)->encoded_bitstream_len();
+    auto actual = std::get<2>(m_encoder)->encoded_bitstream_len() * size_t{8};
     if (actual < target) {
       high_prec = true;
       goto FIXED_RATE_HIGH_PREC_LABEL;

--- a/src/SPECK_FLT.cpp
+++ b/src/SPECK_FLT.cpp
@@ -242,7 +242,7 @@ auto sperr::SPECK_FLT::m_estimate_mse_midtread(double q) const -> double
   return mse;
 }
 
-auto sperr::SPECK_FLT::m_estimate_q(double param) const -> double
+auto sperr::SPECK_FLT::m_estimate_q(double param, bool high_prec) const -> double
 {
   switch (m_mode) {
     case CompMode::PSNR: {
@@ -258,13 +258,25 @@ auto sperr::SPECK_FLT::m_estimate_q(double param) const -> double
     case CompMode::PWE:
       return m_quality * 1.5;
     case CompMode::Rate:
-      // The biggest (odd) double value that sill has a precision of 1 is 0x1.fffffffffffffp52.
-      //    In decimal it's 9007199254740991.0, or approx. 9e15. Given the largest wavelet
-      //    coefficient, we set `m_q` so that the quantized integer is this 0x1.fffffffffffffp52.
+      // This should be the most frequent case, where a `q` is calculated to results in making
+      //    full use of the biggest integer represented by uint32_t (4294967295, or 4e9).
+      //    It is the consideration of performance as well as numeric stability to not use
+      //    a super small q when possible.
+      //
+      if (!high_prec) {
+        return param / static_cast<double>(std::numeric_limits<uint32_t>::max());
+      }
+      // This case is less frequent, and should only occur when a pretty high bitrate is requested.
+      //    Here, we want to have the quantized values no bigger than the biggest (odd) int value
+      //    representable by double and sill has a precision of 1.0. Turns out that this value is
+      //    0x1.fffffffffffffp52, or in decimal 9007199254740991.0, or 9e15.
       //    File `utilities/double_prec.cpp` experiments with double precision approaching here,
       //    and more discussion can be found at:
       //    https://randomascii.wordpress.com/2012/01/11/tricks-with-the-floating-point-format/
-      return param / 0x1.fffffffffffffp52;
+      //
+      else {
+        return param / 0x1.fffffffffffffp52;
+      }
     default:
       return 0.0;
   }
@@ -417,17 +429,20 @@ auto sperr::SPECK_FLT::compress() -> RTNType
                                 [](auto a, auto b) { return std::abs(a) < std::abs(b); });
     param_q = std::abs(*itr);
   }
-  m_q = m_estimate_q(param_q);
+
+  bool high_prec = false;
+FIXED_RATE_HIGH_PREC_LABEL:
+  m_q = m_estimate_q(param_q, high_prec);
   assert(m_q > 0.0);
   m_conditioner.save_q(m_condi_bitstream, m_q);
 
-  // Step 3: quantize floating-point coefficients to integers
+  // Step 3: quantize floating-point coefficients to integers.
   // This step also establishes the integer length used by the encoder/decoder.
   auto rtn = m_midtread_quantize();
   if (rtn != RTNType::Good)
     return rtn;
 
-  // Side step for outlier coding: find out all the outliers, and encode them!
+  // CompMode::PWE only: perform outlier coding: find out all the outliers, and encode them!
   if (m_mode == CompMode::PWE) {
     m_midtread_inv_quantize();
     rtn = m_cdf.take_data(std::move(m_vals_d), m_dims);
@@ -458,7 +473,7 @@ auto sperr::SPECK_FLT::compress() -> RTNType
   // Step 4: Integer SPECK encoding
   m_instantiate_encoder();
   if (m_mode == CompMode::Rate) {
-    size_t total_bits = static_cast<size_t>(m_quality * double(total_vals));
+    auto total_bits = static_cast<size_t>(m_quality * double(total_vals));
     std::visit([total_bits](auto&& encoder) { encoder->set_budget(total_bits); }, m_encoder);
   }
   std::visit([&dims = m_dims](auto&& encoder) { encoder->set_dims(dims); }, m_encoder);
@@ -491,6 +506,20 @@ auto sperr::SPECK_FLT::compress() -> RTNType
     return rtn;
 
   std::visit([](auto&& encoder) { encoder->encode(); }, m_encoder);
+
+  // In CompMode::Rate mode, we see if there's enough bits produced. If not, we adjust `m_q`
+  //    so quantiztion is done with a higher precision.
+  //    Btw I know that GOTO should be used very sparsely and with great caution. I think this
+  //    is one place where it's making the code most clean and not introducing additional risks.
+  if (m_mode == CompMode::Rate && high_prec == false) {
+    auto target = static_cast<size_t>(m_quality * double(total_vals));
+    assert(m_encoder.index() == 2);
+    auto actual = std::get<2>(m_encoder)->encoded_bitstream_len();
+    if (actual < target) {
+      high_prec = true;
+      goto FIXED_RATE_HIGH_PREC_LABEL;
+    }
+  }
 
   return RTNType::Good;
 }

--- a/src/SPECK_INT.cpp
+++ b/src/SPECK_INT.cpp
@@ -318,22 +318,50 @@ void sperr::SPECK_INT<T>::m_refinement_pass_decode()
 {
   // First, process significant pixels previously found.
   //
-  const auto tmp = std::array<uint_type, 2>{uint_type{0}, m_threshold};
   const auto bits_x64 = m_LSP_mask.size() - m_LSP_mask.size() % 64;
 
-  for (size_t i = 0; i < bits_x64; i += 64) {  // Evaluate 64 bits at a time.
-    const auto value = m_LSP_mask.read_long(i);
-    if (value != 0) {
+  if (m_threshold >= uint_type{2}) {
+    const auto half_t = m_threshold / uint_type{2};
+    for (size_t i = 0; i < bits_x64; i += 64) {  // Evaluate 64 bits at a time.
+      const auto value = m_LSP_mask.read_long(i);
+      if (value != 0) {
+        for (size_t j = 0; j < 64; j++) {
+          if ((value >> j) & uint64_t{1}) {
+            if (m_bit_buffer.rbit())
+              m_coeff_buf[i + j] += half_t;
+            else
+              m_coeff_buf[i + j] -= half_t;
+          }
+        }
+      }
+    }
+    for (auto i = bits_x64; i < m_LSP_mask.size(); i++) {  // Evaluate the remaining bits.
+      if (m_LSP_mask.read_bit(i)) {
+        if (m_bit_buffer.rbit())
+          m_coeff_buf[i] += half_t;
+        else
+          m_coeff_buf[i] -= half_t;
+      }
+    }
+  }       // Finish the case where `m_threshold >= 2`.
+  else {  // Start the case where `m_threshold == 1`.
+    for (size_t i = 0; i < bits_x64; i += 64) {
+      const auto value = m_LSP_mask.read_long(i);
       for (size_t j = 0; j < 64; j++) {
-        if ((value >> j) & uint64_t{1})
-          m_coeff_buf[i + j] += tmp[m_bit_buffer.rbit()];
+        if ((value >> j) & uint64_t{1}) {
+          if (!m_bit_buffer.rbit())
+            --(m_coeff_buf[i + j]);
+        }
+      }
+    }
+    for (auto i = bits_x64; i < m_LSP_mask.size(); i++) {
+      if (m_LSP_mask.read_bit(i)) {
+        if (!m_bit_buffer.rbit())
+          --(m_coeff_buf[i]);
       }
     }
   }
-  for (auto i = bits_x64; i < m_LSP_mask.size(); i++) {  // Evaluate the remaining bits.
-    if (m_LSP_mask.read_bit(i))
-      m_coeff_buf[i] += tmp[m_bit_buffer.rbit()];
-  }
+
   assert(m_bit_buffer.rtell() <= m_total_bits);
 
   // Second, mark newly found significant pixels in `m_LSP_mask`

--- a/src/SPECK_INT.cpp
+++ b/src/SPECK_INT.cpp
@@ -385,7 +385,7 @@ void sperr::SPECK_INT<T>::m_refinement_pass_decode()
     }
   }
 
-  assert(m_bit_buffer.rtell() <= m_total_bits);
+  assert(m_bit_buffer.rtell() <= m_avail_bits);
 
   // Second, mark newly found significant pixels in `m_LSP_mask`
   //

--- a/src/SPECK_INT.cpp
+++ b/src/SPECK_INT.cpp
@@ -296,7 +296,7 @@ void sperr::SPECK_INT<T>::m_refinement_pass_encode()
   const auto tmp1 = std::array<uint_type, 2>{uint_type{0}, m_threshold};
   const auto bits_x64 = m_LSP_mask.size() - m_LSP_mask.size() % 64;
 
-  for (size_t i = 0; i < bits_x64; i += 64) {
+  for (size_t i = 0; i < bits_x64; i += 64) { // Evaluate 64 bits at a time.
     const auto value = m_LSP_mask.read_long(i);
     if (value != 0) {
       for (size_t j = 0; j < 64; j++) {
@@ -308,7 +308,7 @@ void sperr::SPECK_INT<T>::m_refinement_pass_encode()
       }
     }
   }
-  for (auto i = bits_x64; i < m_LSP_mask.size(); i++) {
+  for (auto i = bits_x64; i < m_LSP_mask.size(); i++) { // Evaluate the remaining bits.
     if (m_LSP_mask.read_bit(i)) {
       const bool o1 = m_coeff_buf[i] >= m_threshold;
       m_coeff_buf[i] -= tmp1[o1];
@@ -331,7 +331,7 @@ void sperr::SPECK_INT<T>::m_refinement_pass_decode_complete()
   const auto tmp = std::array<uint_type, 2>{uint_type{0}, m_threshold};
   const auto bits_x64 = m_LSP_mask.size() - m_LSP_mask.size() % 64;
 
-  for (size_t i = 0; i < bits_x64; i += 64) {
+  for (size_t i = 0; i < bits_x64; i += 64) { // Evaluate 64 bits at a time.
     const auto value = m_LSP_mask.read_long(i);
     if (value != 0) {
       for (size_t j = 0; j < 64; j++) {
@@ -340,7 +340,7 @@ void sperr::SPECK_INT<T>::m_refinement_pass_decode_complete()
       }
     }
   }
-  for (auto i = bits_x64; i < m_LSP_mask.size(); i++) {
+  for (auto i = bits_x64; i < m_LSP_mask.size(); i++) { // Evaluate the remaining bits.
     if (m_LSP_mask.read_bit(i))
       m_coeff_buf[i] += tmp[m_bit_buffer.rbit()];
   }

--- a/test_scripts/bitstream_unit_test.cpp
+++ b/test_scripts/bitstream_unit_test.cpp
@@ -263,7 +263,7 @@ TEST(Bitmask, CountTrue)
   EXPECT_EQ(m1.count_true(), 20);
 
   m1.resize(60);
-  EXPECT_EQ(m1.count_true(), 12); // 0, 5, ..., 55
+  EXPECT_EQ(m1.count_true(), 12); // 0, 5, ..., 50, 55
 
   m1.resize(192);
   EXPECT_EQ(m1.count_true(), 13); // 0, 5, ..., 55, 60

--- a/test_scripts/speck2d_flt_unit_test.cpp
+++ b/test_scripts/speck2d_flt_unit_test.cpp
@@ -318,8 +318,6 @@ TEST(SPECK2D_FLT, TargetPSNR)
   EXPECT_GT(stats[2], psnr - 0.16); // Another example of not exactly reaching the target PSNR.
 }
 
-#if 0
-// Note: Fixed rate compression yields obviously worse results right now; need more investigation.
 TEST(SPECK2D_FLT, TargetBPP)
 {
   auto inputf = sperr::read_whole_file<float>("../test_data/vorticity.512_512");
@@ -353,12 +351,12 @@ TEST(SPECK2D_FLT, TargetBPP)
   std::printf("bpp = %.2f, PSNR = %.4f, PWE = %.4e\n", 8.0 * bitstream.size() / total_vals,
               stats[2], stats[1]);
 #endif
-  EXPECT_GT(stats[2], 67.3756);
-  EXPECT_LT(stats[1], 2.9784e-6);
+  EXPECT_GT(stats[2], 71.43);
+  EXPECT_LT(stats[1], 2.048e-06);
 
   // Test a another bitrate
   //
-  bpp = 3.1;
+  bpp = 2.0;
   encoder.set_bitrate(bpp);
   encoder.copy_data(inputd.data(), total_vals);
   rtn = encoder.compress();
@@ -377,9 +375,8 @@ TEST(SPECK2D_FLT, TargetBPP)
   std::printf("bpp = %.2f, PSNR = %.4f, PWE = %.4e\n", 8.0 * bitstream.size() / total_vals,
               stats[2], stats[1]);
 #endif
-  EXPECT_GT(stats[2], 62.5555);
-  EXPECT_LT(stats[1], 6.2064e-6);
+  EXPECT_GT(stats[2], 59.6859);
+  EXPECT_LT(stats[1], 8.173e-06);
 }
-#endif
 
 }  // namespace


### PR DESCRIPTION
This PR improves the SPECK integer decoding so that during partial decoding (e.g., progressive access or fixed-rate compression) the reconstruction value is at the center of an interval. It improves accuracy gain in those cases. 