### PR TITLE
Less recursions when depositing morton

### DIFF
--- a/src/SPECK3D_INT_ENC.cpp
+++ b/src/SPECK3D_INT_ENC.cpp
@@ -36,10 +36,11 @@ void sperr::SPECK3D_INT_ENC<T>::m_deposit_set(Set3D set)
       return;
     }
     case 4: {
+      const auto id = set.start_z * m_dims[0] * m_dims[1] + set.start_y * m_dims[0] + set.start_x;
+      auto idx_morton = set.get_morton();
+
       if (set.length_x == 2 && set.length_y == 2) {
         // Element (0, 0, 0)
-        const auto id = set.start_z * m_dims[0] * m_dims[1] + set.start_y * m_dims[0] + set.start_x;
-        auto idx_morton = set.get_morton();
         m_morton_buf[idx_morton] = m_coeff_buf[id];
 
         // Element (1, 0, 0)
@@ -56,8 +57,6 @@ void sperr::SPECK3D_INT_ENC<T>::m_deposit_set(Set3D set)
       }
       else if (set.length_x == 2 && set.length_z == 2) {
         // Element (0, 0, 0)
-        const auto id = set.start_z * m_dims[0] * m_dims[1] + set.start_y * m_dims[0] + set.start_x;
-        auto idx_morton = set.get_morton();
         m_morton_buf[idx_morton] = m_coeff_buf[id];
 
         // Element (1, 0, 0)
@@ -74,8 +73,6 @@ void sperr::SPECK3D_INT_ENC<T>::m_deposit_set(Set3D set)
       }
       else if (set.length_y == 2 && set.length_z == 2) {
         // Element (0, 0, 0)
-        const auto id = set.start_z * m_dims[0] * m_dims[1] + set.start_y * m_dims[0] + set.start_x;
-        auto idx_morton = set.get_morton();
         m_morton_buf[idx_morton] = m_coeff_buf[id];
 
         // Element (0, 1, 0)

--- a/src/SPECK3D_INT_ENC.cpp
+++ b/src/SPECK3D_INT_ENC.cpp
@@ -43,11 +43,10 @@ void sperr::SPECK3D_INT_ENC<T>::m_deposit_set(Set3D set)
         m_morton_buf[idx_morton] = m_coeff_buf[id];
 
         // Element (1, 0, 0)
-        auto id2 = id + 1;
-        m_morton_buf[++idx_morton] = m_coeff_buf[id2];
+        m_morton_buf[++idx_morton] = m_coeff_buf[id + 1];
 
         // Element (0, 1, 0)
-        id2 = id + m_dims[0];
+        auto id2 = id + m_dims[0];
         m_morton_buf[++idx_morton] = m_coeff_buf[id2];
 
         // Element (1, 1, 0)
@@ -62,11 +61,10 @@ void sperr::SPECK3D_INT_ENC<T>::m_deposit_set(Set3D set)
         m_morton_buf[idx_morton] = m_coeff_buf[id];
 
         // Element (1, 0, 0)
-        auto id2 = id + 1;
-        m_morton_buf[++idx_morton] = m_coeff_buf[id2];
-        id2 = id + m_dims[0] * m_dims[1];
+        m_morton_buf[++idx_morton] = m_coeff_buf[id + 1];
 
         // Element (0, 0, 1)
+        auto id2 = id + m_dims[0] * m_dims[1];
         m_morton_buf[++idx_morton] = m_coeff_buf[id2];
 
         // Element (1, 0, 1)
@@ -105,11 +103,10 @@ void sperr::SPECK3D_INT_ENC<T>::m_deposit_set(Set3D set)
         m_morton_buf[idx_morton] = m_coeff_buf[id];
 
         // Element (1, 0, 0)
-        auto id2 = id + 1;
-        m_morton_buf[++idx_morton] = m_coeff_buf[id2];
+        m_morton_buf[++idx_morton] = m_coeff_buf[id + 1];
 
         // Element (0, 1, 0)
-        id2 = id + m_dims[0];
+        auto id2 = id + m_dims[0];
         m_morton_buf[++idx_morton] = m_coeff_buf[id2];
 
         // Element (1, 1, 0)


### PR DESCRIPTION
This PR manually handles 4-element and 8-element cases (instead of relying on recursion) when creating morton organization, so it reduces the number of recursions and also the invocation of dividing sets. It's another obvious performance improvement. 