### PR TITLE
change class layout

### DIFF
--- a/include/Bitmask.h
+++ b/include/Bitmask.h
@@ -61,8 +61,8 @@ class Bitmask {
 #endif
 
  private:
-  std::vector<uint64_t> m_buf;
   size_t m_num_bits = 0;
+  std::vector<uint64_t> m_buf;
 };
 
 };  // namespace sperr

--- a/include/Bitstream.h
+++ b/include/Bitstream.h
@@ -69,11 +69,11 @@ class Bitstream {
   auto get_bitstream(size_t num_bits) const -> std::vector<std::byte>;
 
  private:
-  std::vector<uint64_t> m_buf;
-  std::vector<uint64_t>::iterator m_itr;  // Iterator to the next word to be read/written.
-
   uint64_t m_buffer = 0;  // incoming/outgoing bits
   size_t m_bits = 0;      // number of buffered bits
+
+  std::vector<uint64_t>::iterator m_itr;  // Iterator to the next word to be read/written.
+  std::vector<uint64_t> m_buf;
 };
 
 };  // namespace sperr

--- a/include/SPECK2D_INT.h
+++ b/include/SPECK2D_INT.h
@@ -51,8 +51,8 @@ class SPECK2D_INT : public SPECK_INT<T> {
   //
   // SPECK2D_INT specific data members
   //
-  std::vector<std::vector<Set2D>> m_LIS;
   Set2D m_I;
+  std::vector<std::vector<Set2D>> m_LIS;
 };
 
 };  // namespace sperr

--- a/include/SPECK_FLT.h
+++ b/include/SPECK_FLT.h
@@ -70,8 +70,8 @@ class SPECK_FLT {
   dims_type m_dims = {0, 0, 0};
   vecd_type m_vals_d;
   condi_type m_condi_bitstream;
-  std::vector<vecd_type> m_hierarchy;  // multi-resolution decoding
   Bitmask m_sign_array;
+  std::vector<vecd_type> m_hierarchy;  // multi-resolution decoding
 
   CDF97 m_cdf;
   Conditioner m_conditioner;

--- a/include/SPECK_FLT.h
+++ b/include/SPECK_FLT.h
@@ -62,20 +62,20 @@ class SPECK_FLT {
 
  protected:
   UINTType m_uint_flag = UINTType::UINT64;
+  bool m_has_outlier = false;           // encoding (PWE mode) and decoding
+  CompMode m_mode = CompMode::Unknown;  // encoding only
+  double m_q = 0.0;                     // encoding and decoding
+  double m_quality = 0.0;               // encoding only, represent either PSNR, PWE, or BPP.
+  vecd_type m_vals_orig;                // encoding only (PWE mode)
   dims_type m_dims = {0, 0, 0};
   vecd_type m_vals_d;
-  Bitmask m_sign_array;
   condi_type m_condi_bitstream;
+  std::vector<vecd_type> m_hierarchy;  // multi-resolution decoding
+  Bitmask m_sign_array;
 
   CDF97 m_cdf;
   Conditioner m_conditioner;
   Outlier_Coder m_out_coder;
-
-  std::variant<std::unique_ptr<SPECK_INT<uint8_t>>,
-               std::unique_ptr<SPECK_INT<uint16_t>>,
-               std::unique_ptr<SPECK_INT<uint32_t>>,
-               std::unique_ptr<SPECK_INT<uint64_t>>>
-      m_encoder, m_decoder;
 
   std::variant<std::vector<uint8_t>,
                std::vector<uint16_t>,
@@ -83,13 +83,11 @@ class SPECK_FLT {
                std::vector<uint64_t>>
       m_vals_ui;
 
-  double m_q = 0.0;                     // encoding and decoding
-  bool m_has_outlier = false;           // encoding (PWE mode) and decoding
-  double m_quality = 0.0;               // encoding only, represent either PSNR, PWE, or BPP.
-  vecd_type m_vals_orig;                // encoding only (PWE mode)
-  CompMode m_mode = CompMode::Unknown;  // encoding only
-
-  std::vector<vecd_type> m_hierarchy;  // multi-resolution decoding
+  std::variant<std::unique_ptr<SPECK_INT<uint8_t>>,
+               std::unique_ptr<SPECK_INT<uint16_t>>,
+               std::unique_ptr<SPECK_INT<uint32_t>>,
+               std::unique_ptr<SPECK_INT<uint64_t>>>
+      m_encoder, m_decoder;
 
   // Instantiate `m_vals_ui` based on the chosen integer length.
   void m_instantiate_int_vec();

--- a/include/SPECK_INT.h
+++ b/include/SPECK_INT.h
@@ -73,17 +73,17 @@ class SPECK_INT {
   void m_refinement_pass_decode();
 
   // Data members
-  dims_type m_dims = {0, 0, 0};
   uint_type m_threshold = 0;
-  Bitmask m_LSP_mask, m_LIP_mask, m_sign_array;
-  vecui_type m_coeff_buf;
-  Bitstream m_bit_buffer;
-  std::vector<uint64_t> m_LSP_new;
-
+  uint8_t m_num_bitplanes = 0;
   uint64_t m_total_bits = 0;  // The number of bits of a complete SPECK stream.
   uint64_t m_avail_bits = 0;  // Decoding only. `m_avail_bits` <= `m_total_bits`
-  uint8_t m_num_bitplanes = 0;
   size_t m_budget = std::numeric_limits<size_t>::max();
+
+  dims_type m_dims = {0, 0, 0};
+  vecui_type m_coeff_buf;
+  std::vector<uint64_t> m_LSP_new;
+  Bitmask m_LSP_mask, m_LIP_mask, m_sign_array;
+  Bitstream m_bit_buffer;
 };
 
 };  // namespace sperr

--- a/include/SPECK_INT.h
+++ b/include/SPECK_INT.h
@@ -73,8 +73,8 @@ class SPECK_INT {
   void m_refinement_pass_decode();
 
   // Data members
-  uint_type m_threshold = 0;
   uint8_t m_num_bitplanes = 0;
+  uint_type m_threshold = 0;
   uint64_t m_total_bits = 0;  // The number of bits of a complete SPECK stream.
   uint64_t m_avail_bits = 0;  // Decoding only. `m_avail_bits` <= `m_total_bits`
   size_t m_budget = std::numeric_limits<size_t>::max();

--- a/include/SPERR3D_OMP_C.h
+++ b/include/SPERR3D_OMP_C.h
@@ -32,12 +32,11 @@ class SPERR3D_OMP_C {
   auto get_encoded_bitstream() const -> vec8_type;
 
  private:
+  bool m_orig_is_float = true;  // The original input precision is saved in header.
+  CompMode m_mode = CompMode::Unknown;
+  double m_quality = 0.0;
   dims_type m_dims = {0, 0, 0};        // Dimension of the entire volume
   dims_type m_chunk_dims = {0, 0, 0};  // Preferred dimensions for a chunk
-  bool m_orig_is_float = true;         // The original input precision is saved in header.
-  double m_quality = 0.0;
-  CompMode m_mode = CompMode::Unknown;
-
   std::vector<vec8_type> m_encoded_streams;
 
 #ifdef USE_OMP

--- a/src/SPECK1D_INT.cpp
+++ b/src/SPECK1D_INT.cpp
@@ -24,8 +24,6 @@ void sperr::SPECK1D_INT<T>::m_initialize_lists()
   if (m_LIS.size() < num_of_lists)
     m_LIS.resize(num_of_lists);
   std::for_each(m_LIS.begin(), m_LIS.end(), [](auto& list) { list.clear(); });
-  m_LIP_mask.resize(total_len);
-  m_LIP_mask.reset();
 
   // Put in two sets, each representing a half of the long array.
   Set1D set;

--- a/src/SPECK2D_INT.cpp
+++ b/src/SPECK2D_INT.cpp
@@ -181,11 +181,6 @@ void sperr::SPECK2D_INT<T>::m_initialize_lists()
   for (auto& list : m_LIS)
     list.clear();
 
-  auto total_vals = m_dims[0] * m_dims[1];
-  assert(total_vals > 0);
-  m_LIP_mask.resize(total_vals);
-  m_LIP_mask.reset();
-
   // Prepare the root (S), which is the smallest set after multiple levels of transforms.
   // Note that `num_of_xforms` isn't the same as `num_of_parts`.
   //

--- a/src/SPECK3D_INT.cpp
+++ b/src/SPECK3D_INT.cpp
@@ -25,8 +25,6 @@ void sperr::SPECK3D_INT<T>::m_initialize_lists()
   size_t num_of_sizes = std::accumulate(num_of_parts.cbegin(), num_of_parts.cend(), 1ul);
 
   // Initialize LIS
-  const auto total_vals = m_dims[0] * m_dims[1] * m_dims[2];
-  assert(total_vals > 0);
   if (m_LIS.size() < num_of_sizes)
     m_LIS.resize(num_of_sizes);
   std::for_each(m_LIS.begin(), m_LIS.end(), [](auto& list) { list.clear(); });

--- a/src/SPECK3D_INT.cpp
+++ b/src/SPECK3D_INT.cpp
@@ -30,8 +30,6 @@ void sperr::SPECK3D_INT<T>::m_initialize_lists()
   if (m_LIS.size() < num_of_sizes)
     m_LIS.resize(num_of_sizes);
   std::for_each(m_LIS.begin(), m_LIS.end(), [](auto& list) { list.clear(); });
-  m_LIP_mask.resize(total_vals);
-  m_LIP_mask.reset();
 
   // Starting from a set representing the whole volume, identify the smaller
   //    subsets and put them in the LIS accordingly.

--- a/src/SPECK_INT.cpp
+++ b/src/SPECK_INT.cpp
@@ -106,16 +106,19 @@ void sperr::SPECK_INT<T>::use_bitstream(const void* p, size_t len)
 template <typename T>
 void sperr::SPECK_INT<T>::encode()
 {
-  m_bit_buffer.reserve(m_coeff_buf.size());  // A good starting point
+  m_initialize_lists();
+  const auto coeff_len = m_dims[0] * m_dims[1] * m_dims[2];
+  m_bit_buffer.reserve(coeff_len);  // A good starting point
   m_bit_buffer.rewind();
   m_total_bits = 0;
-  m_initialize_lists();
 
   // Mark every coefficient as insignificant
-  m_LSP_mask.resize(m_coeff_buf.size());
+  m_LSP_mask.resize(coeff_len);
   m_LSP_mask.reset();
   m_LSP_new.clear();
-  m_LSP_new.reserve(m_coeff_buf.size() / 16);
+  m_LSP_new.reserve(coeff_len / 16);
+  m_LIP_mask.resize(coeff_len);
+  m_LIP_mask.reset();
 
   // Treat it as a special case when all coeffs (m_coeff_buf) are zero.
   //    In such a case, we mark `m_num_bitplanes` as zero.
@@ -170,7 +173,9 @@ void sperr::SPECK_INT<T>::decode()
   m_LSP_mask.resize(coeff_len);
   m_LSP_mask.reset();
   m_LSP_new.clear();
-  m_LSP_new.reserve(m_coeff_buf.size() / 16);
+  m_LSP_new.reserve(coeff_len / 16);
+  m_LIP_mask.resize(coeff_len);
+  m_LIP_mask.reset();
 
   // Handle the special case of all coeffs (m_coeff_buf) are zero by return now!
   // This case is indicated by both `m_num_bitplanes` and `m_total_bits` equal zero.


### PR DESCRIPTION
This PR changes the order of data members declared in a few classes. As a result, the size of a class reduced by 8 bytes or 16 bytes in a few of them. 